### PR TITLE
Remove Java serialization

### DIFF
--- a/src/org/iguana/datadependent/ast/AbstractAST.java
+++ b/src/org/iguana/datadependent/ast/AbstractAST.java
@@ -34,8 +34,6 @@ import org.iguana.datadependent.traversal.IAbstractASTVisitor;
 
 public abstract class AbstractAST extends AbstractAttrs {
 	
-	private static final long serialVersionUID = 1L;
-
 	public abstract Object interpret(IEvaluatorContext ctx, Input input);
 	
 	public abstract <T> T accept(IAbstractASTVisitor<T> visitor);

--- a/src/org/iguana/datadependent/ast/Expression.java
+++ b/src/org/iguana/datadependent/ast/Expression.java
@@ -45,23 +45,17 @@ import static java.lang.Integer.toUnsignedLong;
 
 public abstract class Expression extends AbstractAST {
 
-    private static final long serialVersionUID = 1L;
-
     public boolean isBoolean() {
         return false;
     }
 
     public static abstract class Boolean extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         public boolean isBoolean() {
             return true;
         }
 
         static final Boolean TRUE = new Boolean() {
-
-            private static final long serialVersionUID = 1L;
 
             @Override
             public Object interpret(IEvaluatorContext ctx, Input input) {
@@ -80,8 +74,6 @@ public abstract class Expression extends AbstractAST {
         };
 
         static final Boolean FALSE = new Boolean() {
-
-            private static final long serialVersionUID = 1L;
 
             @Override
             public Object interpret(IEvaluatorContext ctx, Input input) {
@@ -107,8 +99,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Integer extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final java.lang.Integer value;
 
@@ -156,8 +146,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class Real extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final java.lang.Float value;
 
         Real(java.lang.Float value) {
@@ -200,8 +188,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class String extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final java.lang.String value;
 
         String(java.lang.String value) {
@@ -242,8 +228,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Tuple extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final Expression[] elements;
         private final int length;
@@ -299,7 +283,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class IntTuple2 extends Expression {
 
-        private static final long serialVersionUID = 1L;
         private final Integer element1;
         private final Integer element2;
         private final Long longValue;
@@ -348,8 +331,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Name extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final java.lang.String name;
         private final int i;
@@ -403,8 +384,6 @@ public abstract class Expression extends AbstractAST {
 
     public static abstract class Call extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         protected final java.lang.String fun;
         protected final Expression[] arguments;
 
@@ -454,8 +433,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Assignment extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final java.lang.String id;
         private final int i;
@@ -515,8 +492,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class LShiftANDEqZero extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression lhs;
         private final Expression rhs;
 
@@ -571,8 +546,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class OrIndent extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final Expression index;
         private final Expression ind;
@@ -664,8 +637,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class AndIndent extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression index;
         private final Expression first;
         private final Expression lExt;
@@ -746,8 +717,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class Or extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression lhs;
         private final Expression rhs;
 
@@ -799,8 +768,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class And extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression lhs;
         private final Expression rhs;
 
@@ -851,8 +818,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Less extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final Expression lhs;
         private final Expression rhs;
@@ -913,8 +878,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class LessThanEqual extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression lhs;
         private final Expression rhs;
 
@@ -973,8 +936,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Greater extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final Expression lhs;
         private final Expression rhs;
@@ -1035,8 +996,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class GreaterThanEqual extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression lhs;
         private final Expression rhs;
 
@@ -1095,8 +1054,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Equal extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final Expression lhs;
         private final Expression rhs;
@@ -1165,8 +1122,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class NotEqual extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression lhs;
         private final Expression rhs;
 
@@ -1226,8 +1181,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class LeftExtent extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         public static java.lang.String format = "%s.lExt";
 
         private final java.lang.String label;
@@ -1275,8 +1228,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class RightExtent extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         public static java.lang.String format = "%s.rExt";
 
@@ -1333,7 +1284,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Yield extends Expression {
-        private static final long serialVersionUID = 1L;
 
         public static java.lang.String format = "%s.yield";
 
@@ -1396,7 +1346,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class Val extends Expression {
-        private static final long serialVersionUID = 1L;
 
         public static java.lang.String format = "%s.val";
 
@@ -1454,8 +1403,6 @@ public abstract class Expression extends AbstractAST {
 
     public static class EndOfFile extends Expression {
 
-        private static final long serialVersionUID = 1L;
-
         private final Expression index;
 
         EndOfFile(Expression index) {
@@ -1499,8 +1446,6 @@ public abstract class Expression extends AbstractAST {
     }
 
     public static class IfThenElse extends Expression {
-
-        private static final long serialVersionUID = 1L;
 
         private final Expression condition;
         private final Expression thenPart;

--- a/src/org/iguana/datadependent/ast/Statement.java
+++ b/src/org/iguana/datadependent/ast/Statement.java
@@ -35,12 +35,8 @@ import java.util.Objects;
 
 public abstract class Statement extends AbstractAST {
 	
-	private static final long serialVersionUID = 1L;
-
 	public static class Expression extends Statement {
 
-		private static final long serialVersionUID = 1L;
-		
 		private final org.iguana.datadependent.ast.Expression exp;
 		
 		Expression(org.iguana.datadependent.ast.Expression exp) {
@@ -82,8 +78,6 @@ public abstract class Statement extends AbstractAST {
 	}
 	
 	public static class VariableDeclaration extends Statement {
-		
-		private static final long serialVersionUID = 1L;
 		
 		private final org.iguana.datadependent.ast.VariableDeclaration decl;
 		

--- a/src/org/iguana/datadependent/ast/VariableDeclaration.java
+++ b/src/org/iguana/datadependent/ast/VariableDeclaration.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 
 public class VariableDeclaration extends AbstractAST {
 	
-	private static final long serialVersionUID = 1L;
-
 	public static Object defaultValue = new Object() {};
 	
 	private final String name;

--- a/src/org/iguana/datadependent/attrs/AbstractAttrs.java
+++ b/src/org/iguana/datadependent/attrs/AbstractAttrs.java
@@ -34,8 +34,6 @@ import java.io.Serializable;
 
 public abstract class AbstractAttrs implements Attr, Serializable {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private transient Set.Immutable<String> env;
 
 	@Override

--- a/src/org/iguana/grammar/Grammar.java
+++ b/src/org/iguana/grammar/Grammar.java
@@ -9,8 +9,9 @@ import org.iguana.regex.visitor.RegularExpressionVisitor;
 import org.iguana.traversal.ISymbolVisitor;
 import org.iguana.util.serialization.JsonSerializer;
 
-import java.io.*;
-import java.net.URI;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 
 public class Grammar {
@@ -21,9 +22,9 @@ public class Grammar {
     private final Symbol layout;
     private final Map<String, Object> globals;
 
-    private Map<String, Set<String>> leftEnds = new HashMap<>();
-    private Map<String, Set<String>> rightEnds = new HashMap<>();
-    private Set<String> ebnfs = new HashSet<>();
+    private final Map<String, Set<String>> leftEnds = new HashMap<>();
+    private final Map<String, Set<String>> rightEnds = new HashMap<>();
+    private final Set<String> ebnfs = new HashSet<>();
 
     private RuntimeGrammar grammar;
 
@@ -151,50 +152,12 @@ public class Grammar {
         return IggyParser.fromGrammar(content);
     }
 
-    public static Grammar load(URI uri, String format) throws FileNotFoundException {
-        return load(new File(uri), format);
-    }
-
-    public static Grammar load(String path, String format) throws FileNotFoundException {
-        return load(new File(path), format);
-    }
-
-    public static Grammar load(File file) throws FileNotFoundException {
-        FileInputStream fis = new FileInputStream(file);
-        return load(fis, "binary");
-    }
-
-    public static Grammar load(File file, String format) throws FileNotFoundException {
-        return load(new FileInputStream(file), format);
-    }
-
-    public static Grammar load(InputStream inputStream) {
-        return load(inputStream, "binary");
-    }
-
-    public static Grammar load(InputStream inputStream, String format) {
-        Grammar grammar;
-        switch (format) {
-            case "binary":
-                try (ObjectInputStream in = new ObjectInputStream(new BufferedInputStream(inputStream))) {
-                    grammar = (Grammar) in.readObject();
-                } catch (IOException | ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
-                break;
-
-            case "json":
-                try {
-                    grammar = JsonSerializer.deserialize(inputStream, Grammar.class);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                break;
-
-            default:
-                throw new RuntimeException("Unsupported format exception");
+    public static Grammar fromJsonFile(String path) {
+        try {
+            return JsonSerializer.deserialize(Files.newInputStream(new File(path).toPath()), Grammar.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        return grammar;
     }
 
     @Override

--- a/src/org/iguana/grammar/Grammar.java
+++ b/src/org/iguana/grammar/Grammar.java
@@ -1,11 +1,11 @@
 package org.iguana.grammar;
 
-import org.iguana.regex.*;
-import org.iguana.regex.visitor.RegularExpressionVisitor;
 import org.iguana.grammar.runtime.*;
 import org.iguana.grammar.symbol.*;
 import org.iguana.grammar.transformation.EBNFToBNF;
 import org.iguana.iggy.IggyParser;
+import org.iguana.regex.*;
+import org.iguana.regex.visitor.RegularExpressionVisitor;
 import org.iguana.traversal.ISymbolVisitor;
 import org.iguana.util.serialization.JsonSerializer;
 
@@ -13,9 +13,7 @@ import java.io.*;
 import java.net.URI;
 import java.util.*;
 
-public class Grammar implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Grammar {
 
     private final List<Rule> rules;
     private final Map<String, RegularExpression> terminals;

--- a/src/org/iguana/grammar/GrammarGraphBuilder.java
+++ b/src/org/iguana/grammar/GrammarGraphBuilder.java
@@ -27,11 +27,6 @@
 
 package org.iguana.grammar;
 
-import org.iguana.regex.CharRange;
-import org.iguana.regex.matcher.DFAMatcherFactory;
-import org.iguana.regex.matcher.MatcherFactory;
-import org.iguana.utils.collections.rangemap.RangeMap;
-import org.iguana.utils.collections.rangemap.RangeMapBuilder;
 import org.iguana.datadependent.ast.Expression;
 import org.iguana.datadependent.ast.Statement;
 import org.iguana.grammar.condition.Condition;
@@ -48,17 +43,19 @@ import org.iguana.grammar.slot.lookahead.FollowTest;
 import org.iguana.grammar.slot.lookahead.RangeTreeFollowTest;
 import org.iguana.grammar.symbol.*;
 import org.iguana.grammar.transformation.VarToInt;
+import org.iguana.regex.CharRange;
+import org.iguana.regex.matcher.DFAMatcherFactory;
+import org.iguana.regex.matcher.MatcherFactory;
 import org.iguana.util.Configuration;
 import org.iguana.util.Configuration.EnvironmentImpl;
+import org.iguana.utils.collections.rangemap.RangeMap;
+import org.iguana.utils.collections.rangemap.RangeMapBuilder;
 
-import java.io.Serializable;
 import java.util.*;
 
 import static org.iguana.grammar.GrammarGraph.epsilonSlot;
 
-public class GrammarGraphBuilder implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class GrammarGraphBuilder {
 
     private Map<Nonterminal, NonterminalGrammarSlot> nonterminalsMap;
 

--- a/src/org/iguana/grammar/condition/Condition.java
+++ b/src/org/iguana/grammar/condition/Condition.java
@@ -30,13 +30,9 @@ package org.iguana.grammar.condition;
 import org.iguana.datadependent.attrs.AbstractAttrs;
 import org.iguana.traversal.IConditionVisitor;
 
-import java.io.Serializable;
 
-
-public abstract class Condition extends AbstractAttrs implements Serializable {
+public abstract class Condition extends AbstractAttrs {
 	
-	private static final long serialVersionUID = 1L;
-
 	protected final ConditionType type;
 
 	public Condition (ConditionType type) {

--- a/src/org/iguana/grammar/condition/DataDependentCondition.java
+++ b/src/org/iguana/grammar/condition/DataDependentCondition.java
@@ -31,8 +31,6 @@ import org.iguana.traversal.IConditionVisitor;
 
 public class DataDependentCondition extends Condition {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final org.iguana.datadependent.ast.Expression expression;
 	
 	private DataDependentCondition(ConditionType type, org.iguana.datadependent.ast.Expression expression) {

--- a/src/org/iguana/grammar/condition/PositionalCondition.java
+++ b/src/org/iguana/grammar/condition/PositionalCondition.java
@@ -36,8 +36,6 @@ import org.iguana.traversal.IConditionVisitor;
  */
 public class PositionalCondition extends Condition {
 	
-	private static final long serialVersionUID = 1L;
-	
 	public PositionalCondition(ConditionType type) {
 		super(type);
 	}

--- a/src/org/iguana/grammar/condition/RegularExpressionCondition.java
+++ b/src/org/iguana/grammar/condition/RegularExpressionCondition.java
@@ -39,8 +39,6 @@ import org.iguana.traversal.IConditionVisitor;
  */
 public class RegularExpressionCondition extends Condition {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final RegularExpression regularExpression;
 	
 	public RegularExpressionCondition(ConditionType type, RegularExpression regularExpression) {

--- a/src/org/iguana/grammar/exception/GrammarValidationException.java
+++ b/src/org/iguana/grammar/exception/GrammarValidationException.java
@@ -31,8 +31,6 @@ import java.util.Set;
 
 public class GrammarValidationException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
 	public GrammarValidationException(Set<RuntimeException> exceptions) {
 		super(getMessage(exceptions));
 	}

--- a/src/org/iguana/grammar/exception/IncorrectNumberOfArgumentsException.java
+++ b/src/org/iguana/grammar/exception/IncorrectNumberOfArgumentsException.java
@@ -32,8 +32,6 @@ import org.iguana.grammar.symbol.Nonterminal;
 
 public class IncorrectNumberOfArgumentsException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
 	public IncorrectNumberOfArgumentsException(Nonterminal nonterminal, Expression[] arguments) {
 		super("Incorrect number of arguments passed to nonterminal " + nonterminal + ": " + arguments.length + " instead of " + nonterminal.getParameters().size());
 	}

--- a/src/org/iguana/grammar/exception/NonterminalNotDefinedException.java
+++ b/src/org/iguana/grammar/exception/NonterminalNotDefinedException.java
@@ -31,8 +31,6 @@ import org.iguana.grammar.symbol.Nonterminal;
 
 public class NonterminalNotDefinedException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
 	private Nonterminal nonterminal;
 
 	public NonterminalNotDefinedException(Nonterminal nonterminal) {

--- a/src/org/iguana/grammar/exception/UndeclaredVariableException.java
+++ b/src/org/iguana/grammar/exception/UndeclaredVariableException.java
@@ -29,8 +29,6 @@ package org.iguana.grammar.exception;
 
 public class UndeclaredVariableException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
 	public UndeclaredVariableException(String name) {
 		super("Undeclared variable: " + name);
 	}

--- a/src/org/iguana/grammar/exception/UndefinedRuntimeValueException.java
+++ b/src/org/iguana/grammar/exception/UndefinedRuntimeValueException.java
@@ -29,8 +29,6 @@ package org.iguana.grammar.exception;
 
 public class UndefinedRuntimeValueException extends RuntimeException {
 	
-	private static final long serialVersionUID = 1L;
-
 	private UndefinedRuntimeValueException() {
 		super("Undefined runtime value.");
 	}

--- a/src/org/iguana/grammar/exception/UnexpectedRuntimeTypeException.java
+++ b/src/org/iguana/grammar/exception/UnexpectedRuntimeTypeException.java
@@ -31,8 +31,6 @@ import org.iguana.datadependent.ast.Expression;
 
 public class UnexpectedRuntimeTypeException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
 	public UnexpectedRuntimeTypeException(Expression expression) {
 		super("Unexpected runtime type of a value: " + expression);
 	}

--- a/src/org/iguana/grammar/exception/UnexpectedSymbol.java
+++ b/src/org/iguana/grammar/exception/UnexpectedSymbol.java
@@ -31,9 +31,6 @@ import org.iguana.grammar.symbol.Symbol;
 
 public class UnexpectedSymbol extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
-	
 	public UnexpectedSymbol(Symbol symbol) {
 		super("Unexpected symbol " + symbol);
 	}

--- a/src/org/iguana/grammar/exception/UnexpectedTypeOfArgumentException.java
+++ b/src/org/iguana/grammar/exception/UnexpectedTypeOfArgumentException.java
@@ -31,8 +31,6 @@ import org.iguana.datadependent.ast.Expression;
 
 public class UnexpectedTypeOfArgumentException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
-	
 	public UnexpectedTypeOfArgumentException(Expression expression) {
 		super("Unexpected type of an operand: " + expression);
 	}

--- a/src/org/iguana/grammar/runtime/AssociativityGroup.java
+++ b/src/org/iguana/grammar/runtime/AssociativityGroup.java
@@ -29,17 +29,14 @@ package org.iguana.grammar.runtime;
 
 import org.iguana.grammar.symbol.Associativity;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.iguana.utils.string.StringUtil.listToString;
 
 
-public class AssociativityGroup implements Serializable {
+public class AssociativityGroup {
 	
-	private static final long serialVersionUID = 1L;
-
 	private final Associativity associativity;
 	
 	private final PrecedenceLevel precedenceLevel;

--- a/src/org/iguana/grammar/runtime/PrecedenceLevel.java
+++ b/src/org/iguana/grammar/runtime/PrecedenceLevel.java
@@ -29,12 +29,9 @@ package org.iguana.grammar.runtime;
 
 import org.iguana.grammar.symbol.Associativity;
 
-import java.io.Serializable;
 import java.util.Arrays;
 
-public class PrecedenceLevel implements Serializable {
-	
-	private static final long serialVersionUID = 1L;
+public class PrecedenceLevel {
 	
 	private final int lhs;
 	private int rhs = -1;

--- a/src/org/iguana/grammar/symbol/AbstractSymbol.java
+++ b/src/org/iguana/grammar/symbol/AbstractSymbol.java
@@ -37,8 +37,6 @@ import static org.iguana.utils.string.StringUtil.listToString;
 
 public abstract class AbstractSymbol extends AbstractAttrs implements Symbol {
 
-	private static final long serialVersionUID = 1L;
-
 	protected final String name;
 
 	protected final String label;

--- a/src/org/iguana/grammar/symbol/Align.java
+++ b/src/org/iguana/grammar/symbol/Align.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 
 public class Align extends AbstractSymbol {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol symbol;
 
 	Align(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Alt.java
+++ b/src/org/iguana/grammar/symbol/Alt.java
@@ -35,8 +35,6 @@ import java.util.stream.Collectors;
 
 public class Alt extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-
 	protected final List<Symbol> symbols;
 	
 	public Alt(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Alternative.java
+++ b/src/org/iguana/grammar/symbol/Alternative.java
@@ -1,14 +1,11 @@
 package org.iguana.grammar.symbol;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class Alternative implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Alternative {
 
     private final List<Sequence> seqs;
     

--- a/src/org/iguana/grammar/symbol/Block.java
+++ b/src/org/iguana/grammar/symbol/Block.java
@@ -36,8 +36,6 @@ import static org.iguana.utils.string.StringUtil.listToString;
 
 public class Block extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol[] symbols;
 
 	Block(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Code.java
+++ b/src/org/iguana/grammar/symbol/Code.java
@@ -39,8 +39,6 @@ import static org.iguana.utils.string.StringUtil.listToString;
 
 public class Code extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol symbol;
 	private final Statement[] statements;
 	

--- a/src/org/iguana/grammar/symbol/Conditional.java
+++ b/src/org/iguana/grammar/symbol/Conditional.java
@@ -35,8 +35,6 @@ import java.util.List;
 
 public class Conditional extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol symbol;
 	private final Expression expression;
 

--- a/src/org/iguana/grammar/symbol/Group.java
+++ b/src/org/iguana/grammar/symbol/Group.java
@@ -41,8 +41,6 @@ import static org.iguana.utils.string.StringUtil.listToString;
  */
 public class Group extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-
 	private final List<Symbol> symbols;
 	
 	public static Group from(List<Symbol> symbols) {

--- a/src/org/iguana/grammar/symbol/Identifier.java
+++ b/src/org/iguana/grammar/symbol/Identifier.java
@@ -7,8 +7,6 @@ import java.util.Set;
 
 public class Identifier extends AbstractSymbol {
 
-    private static final long serialVersionUID = 1L;
-
     private final Set<String> excepts;
 
     public static Identifier fromName(String name) {

--- a/src/org/iguana/grammar/symbol/IfThen.java
+++ b/src/org/iguana/grammar/symbol/IfThen.java
@@ -36,8 +36,6 @@ import java.util.List;
 
 public class IfThen extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Expression expression;
 	private final Symbol thenPart;
 

--- a/src/org/iguana/grammar/symbol/IfThenElse.java
+++ b/src/org/iguana/grammar/symbol/IfThenElse.java
@@ -36,8 +36,6 @@ import java.util.Objects;
 
 public class IfThenElse extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Expression expression;
 	private final Symbol thenPart;
 	private final Symbol elsePart;

--- a/src/org/iguana/grammar/symbol/Ignore.java
+++ b/src/org/iguana/grammar/symbol/Ignore.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 
 public class Ignore extends AbstractSymbol {
 	
-private static final long serialVersionUID = 1L;
-	
 	private final Symbol symbol;
 
 	Ignore(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Nonterminal.java
+++ b/src/org/iguana/grammar/symbol/Nonterminal.java
@@ -38,8 +38,6 @@ import static org.iguana.utils.string.StringUtil.listToString;
 
 public class Nonterminal extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final boolean ebnfList;
 	
 	private final int index;

--- a/src/org/iguana/grammar/symbol/Offside.java
+++ b/src/org/iguana/grammar/symbol/Offside.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 
 public class Offside extends AbstractSymbol {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol symbol;
 
 	Offside(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Opt.java
+++ b/src/org/iguana/grammar/symbol/Opt.java
@@ -34,8 +34,6 @@ import java.util.List;
 
 public class Opt extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-
 	private final Symbol s;
 	
 	private Opt(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Plus.java
+++ b/src/org/iguana/grammar/symbol/Plus.java
@@ -36,8 +36,6 @@ import java.util.List;
 
 public class Plus extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol s;
 	
 	private final List<Symbol> separators;

--- a/src/org/iguana/grammar/symbol/PriorityLevel.java
+++ b/src/org/iguana/grammar/symbol/PriorityLevel.java
@@ -1,15 +1,12 @@
 package org.iguana.grammar.symbol;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * A priority group is a list of alternatives.
  */
-public class PriorityLevel implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class PriorityLevel {
 
     private final List<Alternative> alternatives;
 

--- a/src/org/iguana/grammar/symbol/Return.java
+++ b/src/org/iguana/grammar/symbol/Return.java
@@ -32,8 +32,6 @@ import org.iguana.traversal.ISymbolVisitor;
 
 public class Return extends AbstractSymbol {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final Expression expression;
 	
 	public Return(Builder builder) {

--- a/src/org/iguana/grammar/symbol/Rule.java
+++ b/src/org/iguana/grammar/symbol/Rule.java
@@ -1,6 +1,5 @@
 package org.iguana.grammar.symbol;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -16,9 +15,7 @@ import java.util.Objects;
  *   | G H
  *   ;
  */
-public class Rule implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Rule {
 
     private final Nonterminal head;
 

--- a/src/org/iguana/grammar/symbol/Sequence.java
+++ b/src/org/iguana/grammar/symbol/Sequence.java
@@ -1,14 +1,11 @@
 package org.iguana.grammar.symbol;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class Sequence implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Sequence {
 
     private final List<Symbol> symbols;
 

--- a/src/org/iguana/grammar/symbol/Star.java
+++ b/src/org/iguana/grammar/symbol/Star.java
@@ -36,8 +36,6 @@ import java.util.List;
 
 public class Star extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Symbol s;
 	
 	private final List<Symbol> separators;

--- a/src/org/iguana/grammar/symbol/Start.java
+++ b/src/org/iguana/grammar/symbol/Start.java
@@ -32,8 +32,6 @@ import org.iguana.traversal.ISymbolVisitor;
 
 public class Start extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-
 	private String startSymbol;
 	
     public static Start from(String startSymbol) {

--- a/src/org/iguana/grammar/symbol/Symbol.java
+++ b/src/org/iguana/grammar/symbol/Symbol.java
@@ -27,12 +27,11 @@
 
 package org.iguana.grammar.symbol;
 
-import org.iguana.utils.collections.CollectionsUtil;
 import org.iguana.datadependent.attrs.Attr;
 import org.iguana.grammar.condition.Condition;
 import org.iguana.traversal.ISymbolVisitor;
+import org.iguana.utils.collections.CollectionsUtil;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -58,10 +57,8 @@ import java.util.Set;
  * </pre>
  *
  */
-public interface Symbol extends Serializable, Attr {
+public interface Symbol extends Attr {
 
-	long serialVersionUID = 1L;
-	
 	String getName();
 	
 	Set<Condition> getPreConditions();

--- a/src/org/iguana/grammar/symbol/Terminal.java
+++ b/src/org/iguana/grammar/symbol/Terminal.java
@@ -34,8 +34,6 @@ import org.iguana.traversal.ISymbolVisitor;
 
 public class Terminal extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-
 	private final TerminalNodeType nodeType;
 
 	private final RegularExpression regex;

--- a/src/org/iguana/grammar/symbol/While.java
+++ b/src/org/iguana/grammar/symbol/While.java
@@ -35,8 +35,6 @@ import java.util.List;
 
 public class While extends AbstractSymbol {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final Expression expression;
 	private final Symbol body;
 

--- a/src/org/iguana/regex/AbstractRegularExpression.java
+++ b/src/org/iguana/regex/AbstractRegularExpression.java
@@ -4,8 +4,6 @@ import java.util.Set;
 
 public abstract class AbstractRegularExpression implements RegularExpression {
 
-    private static final long serialVersionUID = 1L;
-
     private final Set<CharRange> lookaheads;
 
     private final Set<CharRange> lookbehinds;

--- a/src/org/iguana/regex/Alt.java
+++ b/src/org/iguana/regex/Alt.java
@@ -34,8 +34,6 @@ import java.util.stream.Collectors;
 
 public class Alt<T extends RegularExpression> extends AbstractRegularExpression implements Iterable<T> {
 
-	private static final long serialVersionUID = 1L;
-
 	protected final List<T> symbols;
 	
 	public Alt(Builder<T> builder) {

--- a/src/org/iguana/regex/Char.java
+++ b/src/org/iguana/regex/Char.java
@@ -40,8 +40,6 @@ import java.util.Set;
  */
 public class Char extends AbstractRegularExpression {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final int val;
 
 	private Char(Builder builder) {

--- a/src/org/iguana/regex/CharRange.java
+++ b/src/org/iguana/regex/CharRange.java
@@ -43,8 +43,6 @@ import static org.iguana.utils.collections.CollectionsUtil.immutableSet;
  */
 public class CharRange extends AbstractRegularExpression implements Range {
 	
-	private static final long serialVersionUID = 1L;
-	
 	private final int start;
 	
 	private final int end;

--- a/src/org/iguana/regex/EOF.java
+++ b/src/org/iguana/regex/EOF.java
@@ -38,8 +38,6 @@ import static org.iguana.utils.collections.CollectionsUtil.immutableSet;
 
 public class EOF extends AbstractRegularExpression {
 	
-	private static final long serialVersionUID = 1L;
-	
 	public static final int TOKEN_ID = 1;
 	
 	public static int VALUE = -1;

--- a/src/org/iguana/regex/Epsilon.java
+++ b/src/org/iguana/regex/Epsilon.java
@@ -38,8 +38,6 @@ import static org.iguana.utils.collections.CollectionsUtil.immutableSet;
 
 public class Epsilon extends AbstractRegularExpression {
 
-	private static final long serialVersionUID = 1L;
-	
 	public static int VALUE = -2;
 	
 	private static final Set<org.iguana.regex.CharRange> firstSet = immutableSet(org.iguana.regex.CharRange.in(VALUE, VALUE));

--- a/src/org/iguana/regex/Opt.java
+++ b/src/org/iguana/regex/Opt.java
@@ -35,8 +35,6 @@ import java.util.Set;
 
 public class Opt extends AbstractRegularExpression {
 
-	private static final long serialVersionUID = 1L;
-
 	private final RegularExpression regex;
 	
 	private Opt(Builder builder) {

--- a/src/org/iguana/regex/Plus.java
+++ b/src/org/iguana/regex/Plus.java
@@ -36,8 +36,6 @@ import java.util.Set;
 
 public class Plus extends AbstractRegularExpression {
 
-	private static final long serialVersionUID = 1L;
-	
 	private final RegularExpression regex;
 	
 	private final List<RegularExpression> separators;

--- a/src/org/iguana/regex/Reference.java
+++ b/src/org/iguana/regex/Reference.java
@@ -6,8 +6,6 @@ import java.util.Set;
 
 public class Reference extends AbstractRegularExpression {
 
-    private static final long serialVersionUID = 1L;
-
     private String name;
 
     public static Reference from(String name) {

--- a/src/org/iguana/regex/RegularExpression.java
+++ b/src/org/iguana/regex/RegularExpression.java
@@ -31,15 +31,12 @@ import org.iguana.regex.automaton.Automaton;
 import org.iguana.regex.visitor.RegularExpressionVisitor;
 import org.iguana.regex.visitor.ToAutomatonRegexVisitor;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
-public interface RegularExpression extends Serializable {
-
-	long serialVersionUID = 1L;
+public interface RegularExpression {
 
 	boolean isNullable();
 

--- a/src/org/iguana/regex/Seq.java
+++ b/src/org/iguana/regex/Seq.java
@@ -34,8 +34,6 @@ import java.util.stream.Collectors;
 
 public class Seq<T extends RegularExpression> extends AbstractRegularExpression implements Iterable<T> {
 
-	private static final long serialVersionUID = 1L;
-
 	private final List<T> symbols;
 
 	public static Seq<Char> from(String s) {

--- a/src/org/iguana/regex/Star.java
+++ b/src/org/iguana/regex/Star.java
@@ -33,8 +33,6 @@ import java.util.*;
 
 public class Star extends AbstractRegularExpression {
 
-    private static final long serialVersionUID = 1L;
-
     private final RegularExpression regex;
 
     private final List<RegularExpression> separators;

--- a/src/org/iguana/regex/automaton/Automaton.java
+++ b/src/org/iguana/regex/automaton/Automaton.java
@@ -30,7 +30,6 @@ package org.iguana.regex.automaton;
 import org.iguana.regex.CharRange;
 import org.iguana.regex.RegularExpression;
 
-import java.io.Serializable;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,9 +42,7 @@ import static java.util.stream.Collectors.toSet;
  * @author Ali Afroozeh
  *
  */
-public class Automaton implements Serializable {
-	
-	private static final long serialVersionUID = 1L;
+public class Automaton {
 
 	private final State startState;
 	

--- a/src/org/iguana/regex/automaton/State.java
+++ b/src/org/iguana/regex/automaton/State.java
@@ -30,12 +30,9 @@ package org.iguana.regex.automaton;
 import org.iguana.regex.CharRange;
 import org.iguana.regex.RegularExpression;
 
-import java.io.Serializable;
 import java.util.*;
 
-public class State implements Serializable {
-
-	private static final long serialVersionUID = 1L;
+public class State {
 
 	private final Set<Transition> transitions;
 	

--- a/src/org/iguana/regex/automaton/Transition.java
+++ b/src/org/iguana/regex/automaton/Transition.java
@@ -35,8 +35,6 @@ import java.io.Serializable;
 
 public class Transition implements Comparable<Transition>, Serializable {
 	
-	private static final long serialVersionUID = 1L;
-
 	private CharRange range;
 	
 	private State destination;

--- a/src/org/iguana/util/Tuple.java
+++ b/src/org/iguana/util/Tuple.java
@@ -27,12 +27,7 @@
 
 package org.iguana.util;
 
-import java.io.Serializable;
-
-
-public class Tuple<T, K> implements Serializable {
-	
-	private static final long serialVersionUID = 1L;
+public class Tuple<T, K> {
 	
 	protected T t;
 	protected K k;

--- a/src/org/iguana/util/UnOrderedTuple.java
+++ b/src/org/iguana/util/UnOrderedTuple.java
@@ -29,8 +29,6 @@ package org.iguana.util;
 
 public class UnOrderedTuple<T, K> extends Tuple<T, K>{
 
-	private static final long serialVersionUID = 1L;
-
 	public UnOrderedTuple(T t, K k) {
 		super(t, k);
 	}
@@ -58,6 +56,4 @@ public class UnOrderedTuple<T, K> extends Tuple<T, K>{
 			    k == null ? other.t == null : k.equals(other.t)); 
 
 	}
-
-
 }

--- a/src/org/iguana/utils/collections/ChainingIntHashMap.java
+++ b/src/org/iguana/utils/collections/ChainingIntHashMap.java
@@ -9,8 +9,6 @@ import java.util.stream.StreamSupport;
 
 public class ChainingIntHashMap<T> implements IntHashMap<T>, Serializable {
 
-	private static final long serialVersionUID = 1L;
-	
 	private static final int DEFAULT_INITIAL_CAPACITY = 16;
 	private static final float DEFAULT_LOAD_FACTOR = 0.75f;
 	

--- a/src/org/iguana/utils/collections/IntHashSet.java
+++ b/src/org/iguana/utils/collections/IntHashSet.java
@@ -1,7 +1,6 @@
 package org.iguana.utils.collections;
 
 
-import java.io.Serializable;
 import java.util.Arrays;
 
 /**
@@ -9,9 +8,7 @@ import java.util.Arrays;
  * @author Ali Afroozeh
  *
  */
-public class IntHashSet implements Serializable {
-	
-	private static final long serialVersionUID = 1L;
+public class IntHashSet {
 	
 	private static final int DEFAULT_INITIAL_CAPACITY = 16;
 	private static final float DEFAULT_LOAD_FACTOR = 0.7f;

--- a/src/org/iguana/utils/collections/tuple/Tuple.java
+++ b/src/org/iguana/utils/collections/tuple/Tuple.java
@@ -27,12 +27,7 @@
 
 package org.iguana.utils.collections.tuple;
 
-import java.io.Serializable;
-
-
-public class Tuple<T, K> implements Serializable {
-	
-	private static final long serialVersionUID = 1L;
+public class Tuple<T, K> {
 	
 	protected T t;
 	protected K k;

--- a/src/org/iguana/utils/collections/tuple/UnOrderedTuple.java
+++ b/src/org/iguana/utils/collections/tuple/UnOrderedTuple.java
@@ -29,8 +29,6 @@ package org.iguana.utils.collections.tuple;
 
 public class UnOrderedTuple<T, K> extends Tuple<T, K>{
 
-	private static final long serialVersionUID = 1L;
-
 	public UnOrderedTuple(T t, K k) {
 		super(t, k);
 	}

--- a/test/org/iguana/GrammarTest.java
+++ b/test/org/iguana/GrammarTest.java
@@ -1,8 +1,5 @@
 package org.iguana;
 
-import org.iguana.utils.input.Input;
-import org.iguana.utils.io.FileUtils;
-import org.iguana.utils.visualization.DotGraph;
 import org.iguana.grammar.Grammar;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.transformation.GrammarTransformer;
@@ -15,6 +12,9 @@ import org.iguana.util.serialization.JsonSerializer;
 import org.iguana.util.serialization.ParseStatisticsSerializer;
 import org.iguana.util.serialization.RecognizerStatisticsSerializer;
 import org.iguana.util.visualization.ParseTreeToDot;
+import org.iguana.utils.input.Input;
+import org.iguana.utils.io.FileUtils;
+import org.iguana.utils.visualization.DotGraph;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -76,12 +76,7 @@ public class GrammarTest {
         if (REGENERATE_FILES || !Files.exists(Paths.get(jsonGrammarPath))) {
             record(grammar, jsonGrammarPath);
         } else {
-            Grammar jsonGrammar;
-            try {
-                jsonGrammar = Grammar.load(jsonGrammarPath, "json");
-            } catch (FileNotFoundException e) {
-                throw new RuntimeException("No grammar.json file is present");
-            }
+            Grammar jsonGrammar = Grammar.fromJsonFile(jsonGrammarPath);
             assertEquals(grammar, jsonGrammar);
         }
 

--- a/test/org/iguana/parser/datadependent/preprocess/TestCSharp.java
+++ b/test/org/iguana/parser/datadependent/preprocess/TestCSharp.java
@@ -27,7 +27,6 @@
 
 package org.iguana.parser.datadependent.preprocess;
 
-import org.iguana.grammar.Grammar;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.grammar.transformation.EBNFToBNF;
@@ -38,7 +37,6 @@ import org.iguana.sppf.NonterminalNode;
 import org.iguana.utils.input.Input;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,11 +47,7 @@ public class TestCSharp {
 	private static RuntimeGrammar originalGrammar;
 
 	static {
-		try {
-			originalGrammar = Grammar.load(new File("grammars/csharp/csharp")).toRuntimeGrammar();
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-		}
+//			originalGrammar = Grammar.load(new File("grammars/csharp/csharp")).toRuntimeGrammar();
 	}
 
 	private static RuntimeGrammar grammar = new LayoutWeaver().transform(new EBNFToBNF().transform(originalGrammar));


### PR DESCRIPTION
This PR removes Java serialization from Iguana. Java serialization was problematic and was not giving any insight into changes. Now the default serialization format is Json.