### PR TITLE
Support for Iguana to Rascal parse tree conversion

### DIFF
--- a/src/org/iguana/grammar/Grammar.java
+++ b/src/org/iguana/grammar/Grammar.java
@@ -315,11 +315,16 @@ public class Grammar {
                     level.containsAssociativityGroup(assocGroup.getLhs(), assocGroup.getRhs());
                 } else {
                     List<Symbol> symbols = new ArrayList<>();
-                    if (alternative.first() == null || alternative.first().isEmpty()) { // Empty alternative
-                        String label = alternative.first() == null ? null : alternative.first().label;
+                    if (alternative.first().isEmpty()) { // Empty alternative
+                        Sequence sequence = alternative.first();
+                        String label = sequence.label;
                         RuntimeRule rule = getRule(head, symbols, Associativity.UNDEFINED, label, resolveIdentifiers, highLevelRule.getLayoutStrategy(), leftEnds, rightEnds, ebnfs);
                         int precedence = level.getPrecedence(rule);
-                        rule = rule.copy().setPrecedence(precedence).setPrecedenceLevel(level).build();
+                        rule = rule.copy()
+                            .setPrecedence(precedence)
+                            .setPrecedenceLevel(level)
+                            .setAttributes(sequence.getAttributes())
+                            .build();
                         rules.add(rule);
                     } else {
                         Sequence sequence = alternative.first();

--- a/src/org/iguana/grammar/Grammar.java
+++ b/src/org/iguana/grammar/Grammar.java
@@ -92,7 +92,6 @@ public class Grammar {
 
             RuntimeGrammar.Builder grammarBuilder = new RuntimeGrammar.Builder();
             for (Rule rule : rules) {
-                if (rule.getHead().toString().equals("$default$")) continue;
                 grammarBuilder.addRules(getRules(rule, resolveIdentifiers, leftEnds, rightEnds, ebnfs));
             }
             grammarBuilder.setStartSymbol(startSymbol);
@@ -146,7 +145,6 @@ public class Grammar {
 
     private void computeEnds(Map<String, Set<String>> leftEnds, Map<String, Set<String>> rightEnds, Set<String> ebnfs) {
         for (Rule rule : rules) {
-            if (rule.getHead().toString().equals("$default$")) continue;
             for (PriorityLevel priorityLevel : rule.getPriorityLevels()) {
                 for (Alternative alternative : priorityLevel.getAlternatives()) {
                     for (Sequence seq : alternative.seqs()) {

--- a/src/org/iguana/grammar/Grammar.java
+++ b/src/org/iguana/grammar/Grammar.java
@@ -303,7 +303,12 @@ public class Grammar {
                         Sequence sequence = seqIt.previous();
                         RuntimeRule rule = getRule(head, sequence.getSymbols(), sequence.associativity, sequence.label, resolveIdentifiers, highLevelRule.getLayoutStrategy(), leftEnds, rightEnds, ebnfs);
                         int precedence = assocGroup.getPrecedence(rule);
-                        rule = rule.copyBuilder().setPrecedence(precedence).setPrecedenceLevel(level).setAssociativityGroup(assocGroup).build();
+                        rule = rule.copy()
+                            .setPrecedence(precedence)
+                            .setPrecedenceLevel(level)
+                            .setAssociativityGroup(assocGroup)
+                            .setAttributes(sequence.getAttributes())
+                            .build();
                         rules.add(rule);
                     }
                     assocGroup.done();
@@ -314,15 +319,20 @@ public class Grammar {
                         String label = alternative.first() == null ? null : alternative.first().label;
                         RuntimeRule rule = getRule(head, symbols, Associativity.UNDEFINED, label, resolveIdentifiers, highLevelRule.getLayoutStrategy(), leftEnds, rightEnds, ebnfs);
                         int precedence = level.getPrecedence(rule);
-                        rule = rule.copyBuilder().setPrecedence(precedence).setPrecedenceLevel(level).build();
+                        rule = rule.copy().setPrecedence(precedence).setPrecedenceLevel(level).build();
                         rules.add(rule);
                     } else {
-                        symbols.add(alternative.first().first());
-                        if (alternative.first().rest() != null)
-                            addAll(symbols, alternative.first().rest());
-                        RuntimeRule rule = getRule(head, symbols, alternative.first().associativity, alternative.first().label, resolveIdentifiers, highLevelRule.getLayoutStrategy(), leftEnds, rightEnds, ebnfs);
+                        Sequence sequence = alternative.first();
+                        symbols.add(sequence.first());
+                        if (sequence.rest() != null)
+                            addAll(symbols, sequence.rest());
+                        RuntimeRule rule = getRule(head, symbols, sequence.associativity, sequence.label, resolveIdentifiers, highLevelRule.getLayoutStrategy(), leftEnds, rightEnds, ebnfs);
                         int precedence = level.getPrecedence(rule);
-                        rule = rule.copyBuilder().setPrecedence(precedence).setPrecedenceLevel(level).build();
+                        rule = rule.copy()
+                            .setPrecedence(precedence)
+                            .setPrecedenceLevel(level)
+                            .setAttributes(sequence.getAttributes())
+                            .build();
                         rules.add(rule);
                     }
                 }

--- a/src/org/iguana/grammar/GrammarGraph.java
+++ b/src/org/iguana/grammar/GrammarGraph.java
@@ -1,13 +1,15 @@
 package org.iguana.grammar;
 
 import org.iguana.datadependent.ast.Expression;
-import org.iguana.regex.matcher.DFAMatcherFactory;
 import org.iguana.grammar.slot.BodyGrammarSlot;
 import org.iguana.grammar.slot.GrammarSlot;
 import org.iguana.grammar.slot.NonterminalGrammarSlot;
 import org.iguana.grammar.slot.TerminalGrammarSlot;
+import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.grammar.symbol.Terminal;
+import org.iguana.regex.matcher.DFAMatcherFactory;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -17,12 +19,12 @@ public class GrammarGraph {
 
     public static final TerminalGrammarSlot epsilonSlot = new TerminalGrammarSlot(Terminal.epsilon(), new DFAMatcherFactory());
     private final List<GrammarSlot> slots;
-    private NonterminalGrammarSlot startSlot;
     private final Map<String, Expression> globals;
+    private final Map<Nonterminal, NonterminalGrammarSlot> nonterminalsMap;
 
-    public GrammarGraph(List<GrammarSlot> slots, NonterminalGrammarSlot startSlot, Map<String, Expression> globals) {
+    public GrammarGraph(List<GrammarSlot> slots, Map<Nonterminal, NonterminalGrammarSlot> nonterminalsMap, Map<String, Expression> globals) {
         this.slots = slots;
-        this.startSlot = startSlot;
+        this.nonterminalsMap = nonterminalsMap;
         this.globals = globals;
     }
 
@@ -38,8 +40,8 @@ public class GrammarGraph {
         return slots.stream().filter(slot -> slot instanceof BodyGrammarSlot).map(slot -> (BodyGrammarSlot) slot).collect(toList());
     }
 
-    public NonterminalGrammarSlot getStartSlot() {
-        return startSlot;
+    public NonterminalGrammarSlot getStartSlot(Nonterminal nonterminal) {
+        return nonterminalsMap.get(nonterminal);
     }
 
     public void clear() {

--- a/src/org/iguana/grammar/GrammarGraphBuilder.java
+++ b/src/org/iguana/grammar/GrammarGraphBuilder.java
@@ -57,36 +57,36 @@ import static org.iguana.grammar.GrammarGraph.epsilonSlot;
 
 public class GrammarGraphBuilder {
 
-    private Map<Nonterminal, NonterminalGrammarSlot> nonterminalsMap;
+    private final Map<Nonterminal, NonterminalGrammarSlot> nonterminalsMap;
 
-    private Map<Terminal, TerminalGrammarSlot> terminalsMap;
+    private final Map<Terminal, TerminalGrammarSlot> terminalsMap;
 
-    private List<BodyGrammarSlot> bodyGrammarSlots;
+    private final List<BodyGrammarSlot> bodyGrammarSlots;
 
     private FirstFollowSets firstFollow;
 
-    private RuntimeGrammar grammar;
+    private final RuntimeGrammar grammar;
 
-    private Configuration config;
+    private final Configuration config;
 
     private final Map<Integer, Map<String, Integer>> mapping;
 
     private Map<String, Integer> current;
 
-    private static MatcherFactory matcherFactory = new DFAMatcherFactory();
+    private static final MatcherFactory matcherFactory = new DFAMatcherFactory();
 
-    public static GrammarGraph from(RuntimeGrammar grammar) {
-        return from(grammar, Configuration.load());
+    public static GrammarGraph from(RuntimeGrammar grammar, Nonterminal start) {
+        return from(grammar, start, Configuration.load());
     }
 
-    public static GrammarGraph from(RuntimeGrammar grammar, Configuration config) {
+    public static GrammarGraph from(RuntimeGrammar grammar, Nonterminal start, Configuration config) {
         GrammarGraphBuilder builder = new GrammarGraphBuilder(grammar, config);
         builder.convert();
         List<GrammarSlot> grammarSlots = new ArrayList<>();
         grammarSlots.addAll(builder.nonterminalsMap.values());
         grammarSlots.addAll(builder.terminalsMap.values());
         grammarSlots.addAll(builder.bodyGrammarSlots);
-        return new GrammarGraph(grammarSlots, builder.getHead(Nonterminal.withName(grammar.getStartSymbol().getName())), grammar.getGlobals());
+        return new GrammarGraph(grammarSlots, builder.getHead(start), grammar.getGlobals());
     }
 
     private void convert() {

--- a/src/org/iguana/grammar/GrammarGraphBuilder.java
+++ b/src/org/iguana/grammar/GrammarGraphBuilder.java
@@ -75,18 +75,18 @@ public class GrammarGraphBuilder {
 
     private static final MatcherFactory matcherFactory = new DFAMatcherFactory();
 
-    public static GrammarGraph from(RuntimeGrammar grammar, Nonterminal start) {
-        return from(grammar, start, Configuration.load());
+    public static GrammarGraph from(RuntimeGrammar grammar) {
+        return from(grammar, Configuration.load());
     }
 
-    public static GrammarGraph from(RuntimeGrammar grammar, Nonterminal start, Configuration config) {
+    public static GrammarGraph from(RuntimeGrammar grammar, Configuration config) {
         GrammarGraphBuilder builder = new GrammarGraphBuilder(grammar, config);
         builder.convert();
         List<GrammarSlot> grammarSlots = new ArrayList<>();
         grammarSlots.addAll(builder.nonterminalsMap.values());
         grammarSlots.addAll(builder.terminalsMap.values());
         grammarSlots.addAll(builder.bodyGrammarSlots);
-        return new GrammarGraph(grammarSlots, builder.getHead(start), grammar.getGlobals());
+        return new GrammarGraph(grammarSlots, builder.nonterminalsMap, grammar.getGlobals());
     }
 
     private void convert() {

--- a/src/org/iguana/grammar/exception/NonterminalNotDefinedException.java
+++ b/src/org/iguana/grammar/exception/NonterminalNotDefinedException.java
@@ -31,7 +31,7 @@ import org.iguana.grammar.symbol.Nonterminal;
 
 public class NonterminalNotDefinedException extends RuntimeException {
 
-	private Nonterminal nonterminal;
+	private final Nonterminal nonterminal;
 
 	public NonterminalNotDefinedException(Nonterminal nonterminal) {
 		super(nonterminal + " not defined.");

--- a/src/org/iguana/grammar/exception/NonterminalNotDefinedException.java
+++ b/src/org/iguana/grammar/exception/NonterminalNotDefinedException.java
@@ -37,26 +37,8 @@ public class NonterminalNotDefinedException extends RuntimeException {
 		super(nonterminal + " not defined.");
 		this.nonterminal = nonterminal;
 	}
-	
-	@Override
-	public int hashCode() {
-		return nonterminal.hashCode();
+
+	public Nonterminal getNonterminal() {
+		return nonterminal;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (this == obj) {
-			return true;
-		}
-		
-		if (!(obj instanceof NonterminalNotDefinedException)) {
-			return false;
-		}
-		
-		NonterminalNotDefinedException other = (NonterminalNotDefinedException) obj;
-		
-		return nonterminal.equals(other.nonterminal);
-	}
-	
 }

--- a/src/org/iguana/grammar/runtime/RuntimeGrammar.java
+++ b/src/org/iguana/grammar/runtime/RuntimeGrammar.java
@@ -159,7 +159,7 @@ public class RuntimeGrammar {
 		StringBuilder sb = new StringBuilder();
 		
 		for (Nonterminal nonterminal : definitions.keySet()) {
-			sb.append(nonterminal).append(" ::= ");
+			sb.append(nonterminal).append(" = ");
 			for (List<Symbol> alternatives : definitions.get(nonterminal).stream().map(r -> r.getBody()).collect(Collectors.toList())) {
 				if (alternatives == null) continue;
 				sb.append(listToString(alternatives)).append("\n");

--- a/src/org/iguana/grammar/runtime/RuntimeRule.java
+++ b/src/org/iguana/grammar/runtime/RuntimeRule.java
@@ -211,13 +211,8 @@ public class RuntimeRule {
 
     @Override
 	public String toString() {
-
-		if(body == null) {
-			return "";
-		}
-		
 		StringBuilder sb = new StringBuilder();
-		sb.append(head).append(" ::= ");
+		sb.append(head).append(" = ");
 		for(Symbol s : body) {
 			sb.append(s).append(" ");
 		}
@@ -270,7 +265,7 @@ public class RuntimeRule {
 		return new Position(this, i, j);
 	}
 	
-	public Builder copyBuilder() {
+	public Builder copy() {
 		return new Builder(this);
 	}
 	
@@ -304,7 +299,7 @@ public class RuntimeRule {
     public static class Builder {
 
         private Nonterminal head;
-        private List<Symbol> body;
+        private List<Symbol> body = new ArrayList<>();
         private LayoutStrategy layoutStrategy = LayoutStrategy.INHERITED;
         private Symbol layout;
 
@@ -326,11 +321,9 @@ public class RuntimeRule {
 
         private Map<String, Object> attributes = new HashMap<>();
         private Symbol definition;
-        public boolean terminalRule;
 
         public Builder(Nonterminal head) {
             this.head = head;
-            this.body = new ArrayList<>();
         }
 
         public Builder() {}

--- a/src/org/iguana/grammar/symbol/AbstractSymbol.java
+++ b/src/org/iguana/grammar/symbol/AbstractSymbol.java
@@ -32,7 +32,7 @@ import org.iguana.grammar.condition.Condition;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static org.iguana.utils.string.StringUtil.listToString;
 
@@ -46,6 +46,8 @@ public abstract class AbstractSymbol extends AbstractAttrs implements Symbol {
 
 	protected final List<Condition> postConditions;
 
+	private final Map<String, Object> attributes;
+
 	public AbstractSymbol(SymbolBuilder<? extends Symbol> builder) {
 		if (builder.name == null) 
 			throw new IllegalArgumentException("Name cannot be null");
@@ -53,6 +55,7 @@ public abstract class AbstractSymbol extends AbstractAttrs implements Symbol {
 		this.label = builder.label;
 		this.preConditions = builder.preConditions.isEmpty() ? Collections.emptyList() : builder.preConditions;
 		this.postConditions = builder.postConditions.isEmpty() ? Collections.emptyList() : builder.postConditions;
+		this.attributes = builder.attributes.isEmpty() ? Collections.emptyMap() : builder.attributes;
 	}
 	
 	@Override
@@ -85,10 +88,13 @@ public abstract class AbstractSymbol extends AbstractAttrs implements Symbol {
 		return s;
 	}
 	
-	
 	@Override
 	public String toString(int j) {
 		return this + (j == 1 ? " . " : "");
 	}
-	
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
 }

--- a/src/org/iguana/grammar/symbol/CodeHolder.java
+++ b/src/org/iguana/grammar/symbol/CodeHolder.java
@@ -6,6 +6,7 @@ import org.iguana.traversal.ISymbolVisitor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class CodeHolder implements org.iguana.grammar.symbol.Symbol {
@@ -48,6 +49,11 @@ public class CodeHolder implements org.iguana.grammar.symbol.Symbol {
     @Override
     public String toString(int j) {
         return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/src/org/iguana/grammar/symbol/Nonterminal.java
+++ b/src/org/iguana/grammar/symbol/Nonterminal.java
@@ -52,8 +52,6 @@ public class Nonterminal extends AbstractSymbol {
 	
 	private final Set<String> excepts;
 	
-	private final Map<String, Object> attributes;
-
 	/**
 	 * The type of this nonterminal. This field is used to track EBNF to BNF conversion
 	 * information for each nonterminal. See NonterminalNodeType.
@@ -74,7 +72,6 @@ public class Nonterminal extends AbstractSymbol {
 		this.arguments = builder.arguments;
 		this.excepts = builder.excepts;
 		this.nodeType = builder.nodeType;
-		this.attributes = builder.attributes;
 	}
 	
 	public boolean isEbnfList() {
@@ -112,10 +109,6 @@ public class Nonterminal extends AbstractSymbol {
 	public NonterminalNodeType getNodeType() {
 		return nodeType;
 	}
-
-    public Map<String, Object> getAttributes() {
-        return attributes;
-    }
 
 	@Override
 	public String toString() {
@@ -186,7 +179,6 @@ public class Nonterminal extends AbstractSymbol {
 			this.arguments = nonterminal.arguments;
 			this.excepts = nonterminal.excepts;
 			this.nodeType = nonterminal.nodeType;
-			this.attributes = nonterminal.attributes;
 		}
 
 		public Builder(String name) {

--- a/src/org/iguana/grammar/symbol/Sequence.java
+++ b/src/org/iguana/grammar/symbol/Sequence.java
@@ -45,6 +45,10 @@ public class Sequence {
         return label;
     }
 
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;

--- a/src/org/iguana/grammar/symbol/Sequence.java
+++ b/src/org/iguana/grammar/symbol/Sequence.java
@@ -72,15 +72,16 @@ public class Sequence {
             sb.append("  ").append("%").append(label);
         }
         if (!attributes.isEmpty()) {
-            sb.append("  ");
+            sb.append("  {");
             for (Map.Entry<String, Object> entry : attributes.entrySet()) {
                 if (entry.getValue() == null) {
-                    sb.append(String.format("@%s ", entry.getKey()));
+                    sb.append(String.format("%s ", entry.getKey()));
                 } else {
-                    sb.append(String.format("@%s=%s ", entry.getKey(), entry.getValue()));
+                    sb.append(String.format("%s=%s ", entry.getKey(), entry.getValue()));
                 }
             }
             sb.deleteCharAt(sb.length() - 1);
+            sb.append("}");
         }
         return sb.toString();
     }

--- a/src/org/iguana/grammar/symbol/Start.java
+++ b/src/org/iguana/grammar/symbol/Start.java
@@ -49,7 +49,7 @@ public class Start extends AbstractSymbol {
 
 	@Override
 	public Builder copy() {
-		return new Builder(name);
+		return new Builder(startSymbol);
 	}
 
     @Override

--- a/src/org/iguana/grammar/symbol/Symbol.java
+++ b/src/org/iguana/grammar/symbol/Symbol.java
@@ -33,6 +33,7 @@ import org.iguana.traversal.ISymbolVisitor;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -77,6 +78,8 @@ public interface Symbol extends Attr {
 	}
 		
 	String toString(int j);
+
+	Map<String, Object> getAttributes();
 	
 	<T> T accept(ISymbolVisitor<T> visitor);
 }	

--- a/src/org/iguana/grammar/symbol/SymbolBuilder.java
+++ b/src/org/iguana/grammar/symbol/SymbolBuilder.java
@@ -29,9 +29,7 @@ package org.iguana.grammar.symbol;
 
 import org.iguana.grammar.condition.Condition;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 public abstract class SymbolBuilder<T extends Symbol> {
 	
@@ -42,13 +40,17 @@ public abstract class SymbolBuilder<T extends Symbol> {
 	protected Object object;
 
 	protected List<Condition> preConditions = new ArrayList<>();
+
 	protected List<Condition> postConditions = new ArrayList<>();
+
+	protected Map<String, Object> attributes = new HashMap<>();
 
 	public SymbolBuilder(T symbol) {
 		this.name = symbol.getName();
 		this.label = symbol.getLabel();
 		this.preConditions = new ArrayList<>(symbol.getPreConditions());
 		this.postConditions = new ArrayList<>(symbol.getPostConditions());
+		this.attributes = new HashMap<>(symbol.getAttributes());
 	}
 	
 	public SymbolBuilder() { }
@@ -112,6 +114,11 @@ public abstract class SymbolBuilder<T extends Symbol> {
 
 	public SymbolBuilder<T> setPostConditions(List<Condition> conditions) {
 		postConditions = new ArrayList<>(conditions);
+		return this;
+	}
+
+	public SymbolBuilder<T> addAttribute(String key, Object value) {
+		this.attributes.put(key, value);
 		return this;
 	}
 

--- a/src/org/iguana/grammar/transformation/DesugarAlignAndOffside.java
+++ b/src/org/iguana/grammar/transformation/DesugarAlignAndOffside.java
@@ -147,7 +147,7 @@ public class DesugarAlignAndOffside implements GrammarTransformation {
 			
 			if (doAlign) {
 				List<Symbol> symbols = new ArrayList<>();
-				RuntimeRule.Builder builder = rule.copyBuilder();
+				RuntimeRule.Builder builder = rule.copy();
 				
 				if (this.rule.getBody() != null) {
 					
@@ -181,7 +181,7 @@ public class DesugarAlignAndOffside implements GrammarTransformation {
 			if (isOffsided)
 				builder = rule.copyBuilderButWithHead(rule.getHead().copy().addParameters(index, ind, first).build());
 			else
-				builder = rule.copyBuilder();
+				builder = rule.copy();
 			
 			List<Symbol> symbols = new ArrayList<>();
 			

--- a/src/org/iguana/grammar/transformation/DesugarPrecedenceAndAssociativity.java
+++ b/src/org/iguana/grammar/transformation/DesugarPrecedenceAndAssociativity.java
@@ -2172,7 +2172,7 @@ public class DesugarPrecedenceAndAssociativity implements GrammarTransformation 
 						builder = rule.copyBuilderButWithHead(rule.getHead().copy().addParameters("l","r").build());
 					else if (isHeadWithLabeledRules)
 						builder = rule.copyBuilderButWithHead(rule.getHead().copy().addParameters("_not").build());
-					else builder = rule.copyBuilder();
+					else builder = rule.copy();
 					
 					builder = builder.setSymbols(symbols);
 					
@@ -2202,7 +2202,7 @@ public class DesugarPrecedenceAndAssociativity implements GrammarTransformation 
 						builder = rule.copyBuilderButWithHead(rule.getHead().copy().addParameters("p").build());
 					else if (isHeadWithLabeledRules)
 						builder = rule.copyBuilderButWithHead(rule.getHead().copy().addParameters("_not").build());
-					else builder = rule.copyBuilder();
+					else builder = rule.copy();
 					
 					boolean isIndirectEnd = false;
 					

--- a/src/org/iguana/grammar/transformation/DesugarStartSymbol.java
+++ b/src/org/iguana/grammar/transformation/DesugarStartSymbol.java
@@ -11,35 +11,31 @@ import org.iguana.grammar.symbol.Start;
 
 public class DesugarStartSymbol implements GrammarTransformation {
 
-    private final String startSymbolName;
+    private final Start start;
 
-    public DesugarStartSymbol(String startSymbolName) {
-        this.startSymbolName = startSymbolName;
+    public DesugarStartSymbol(Start start) {
+        this.start = start;
     }
 
     @Override
     public RuntimeGrammar transform(RuntimeGrammar grammar) {
-        if (startSymbolName == null) return grammar;
-
-        Start startSymbol = Start.from(startSymbolName);
-
         RuntimeGrammar.Builder builder = new RuntimeGrammar.Builder(grammar);
 
-        Nonterminal startNonterminal = new Nonterminal.Builder(startSymbol.getName()).setNodeType(NonterminalNodeType.Start).build();
+        Nonterminal startNonterminal = new Nonterminal.Builder(start.getName()).setNodeType(NonterminalNodeType.Start).build();
 
         RuntimeRule startRule = RuntimeRule.withHead(startNonterminal)
             // TODO: For now we use the label top, but would be good to allow configuring it.
-            .addSymbol(new Nonterminal.Builder(startSymbolName).setLabel("top").build())
+            .addSymbol(new Nonterminal.Builder(start.getStartSymbol()).setLabel("top").build())
             .setRecursion(Recursion.NON_REC)
             .setAssociativity(Associativity.UNDEFINED)
             .setPrecedence(-1)
             .setPrecedenceLevel(PrecedenceLevel.getFirstAndDone())
-            .setDefinition(startSymbol)
+            .setDefinition(start)
             .build();
 
         builder.addRule(startRule);
         builder.setGlobals(grammar.getGlobals());
-        builder.setStartSymbol(startSymbol);
+        builder.setStartSymbol(start);
         return builder.build();
     }
 }

--- a/src/org/iguana/grammar/transformation/DesugarState.java
+++ b/src/org/iguana/grammar/transformation/DesugarState.java
@@ -175,7 +175,7 @@ public class DesugarState implements GrammarTransformation {
 		}
 		
 		if (builder == null)
-			builder = rule.copyBuilder();
+			builder = rule.copy();
 		
 		List<Symbol> symbols = new ArrayList<>();
 		

--- a/src/org/iguana/grammar/transformation/EBNFToBNF.java
+++ b/src/org/iguana/grammar/transformation/EBNFToBNF.java
@@ -103,6 +103,7 @@ public class EBNFToBNF implements GrammarTransformation {
 				.setLeftEnds(rule.getLeftEnds())
 				.setRightEnds(rule.getRightEnds())
 				.setLabel(rule.getLabel())
+				.setAttributes(rule.getAttributes())
 				.setDefinition(rule.getDefinition())
 				.build();
 	}

--- a/src/org/iguana/grammar/transformation/GrammarTransformer.java
+++ b/src/org/iguana/grammar/transformation/GrammarTransformer.java
@@ -14,7 +14,7 @@ public class GrammarTransformer {
         grammar = desugarAlignAndOffside.transform(grammar);
         Start startSymbol = runtimeGrammar.getStartSymbol();
         if (startSymbol != null) {
-            grammar = new DesugarStartSymbol(startSymbol.getStartSymbol()).transform(grammar);
+            grammar = new DesugarStartSymbol(startSymbol).transform(grammar);
         }
         DesugarPrecedenceAndAssociativity precedenceAndAssociativity = new DesugarPrecedenceAndAssociativity();
         precedenceAndAssociativity.setOP2();

--- a/src/org/iguana/grammar/transformation/GrammarTransformer.java
+++ b/src/org/iguana/grammar/transformation/GrammarTransformer.java
@@ -1,21 +1,21 @@
 package org.iguana.grammar.transformation;
 
 import org.iguana.grammar.runtime.RuntimeGrammar;
+import org.iguana.grammar.symbol.Start;
 
 public class GrammarTransformer {
 
     public static RuntimeGrammar transform(RuntimeGrammar runtimeGrammar) {
-        return transform(runtimeGrammar, runtimeGrammar.getStartSymbol().getStartSymbol());
-    }
-
-    public static RuntimeGrammar transform(RuntimeGrammar runtimeGrammar, String startNonterminal) {
         DesugarAlignAndOffside desugarAlignAndOffside = new DesugarAlignAndOffside();
         desugarAlignAndOffside.doAlign();
         RuntimeGrammar grammar = desugarAlignAndOffside.transform(runtimeGrammar);
         grammar = new EBNFToBNF().transform(grammar);
         desugarAlignAndOffside.doOffside();
         grammar = desugarAlignAndOffside.transform(grammar);
-        grammar = new DesugarStartSymbol(startNonterminal).transform(grammar);
+        Start startSymbol = runtimeGrammar.getStartSymbol();
+        if (startSymbol != null) {
+            grammar = new DesugarStartSymbol(startSymbol.getStartSymbol()).transform(grammar);
+        }
         DesugarPrecedenceAndAssociativity precedenceAndAssociativity = new DesugarPrecedenceAndAssociativity();
         precedenceAndAssociativity.setOP2();
         grammar = precedenceAndAssociativity.transform(grammar);

--- a/src/org/iguana/grammar/transformation/LayoutWeaver.java
+++ b/src/org/iguana/grammar/transformation/LayoutWeaver.java
@@ -57,6 +57,7 @@ public class LayoutWeaver implements GrammarTransformation {
 												.setPrecedence(rule.getPrecedence())
 												.setPrecedenceLevel(rule.getPrecedenceLevel())
 												.setLabel(rule.getLabel())
+												.setAttributes(rule.getAttributes())
 												.setDefinition(rule.getDefinition());
 
 			if (rule.size() == 0) {

--- a/src/org/iguana/iggy/IggyParseTreeToGrammarVisitor.java
+++ b/src/org/iguana/iggy/IggyParseTreeToGrammarVisitor.java
@@ -166,17 +166,6 @@ public class IggyParseTreeToGrammarVisitor implements IggyParseTreeVisitor<Objec
     }
 
     @Override
-    public Alternative visitEmptyAlternative(IggyParseTree.EmptyAlternative node) {
-        Optional<String> label = (Optional<String>) node.label().accept(this);
-        if (label.isPresent()) {
-            Sequence sequence = new Sequence.Builder().setLabel(label.get()).build();
-            return new Alternative.Builder().addSequence(sequence).build();
-        } else {
-            return new Alternative.Builder().build();
-        }
-    }
-
-    @Override
     public Sequence visitMoreThanOneElemSequence(IggyParseTree.MoreThanOneElemSequence node) {
         Associativity associativity = null;
         if (node.hasChildren()) {
@@ -228,6 +217,12 @@ public class IggyParseTreeToGrammarVisitor implements IggyParseTreeVisitor<Objec
             builder.setLabel(label.get());
         }
         return builder.build();
+    }
+
+    @Override
+    public Sequence visitEmptySequence(IggyParseTree.EmptySequence node) {
+        Optional<String> label = (Optional<String>) node.label().accept(this);
+        return new Sequence.Builder().setLabel(label.orElse(null)).build();
     }
 
     @Override

--- a/src/org/iguana/iggy/gen/IggyParseTree.java
+++ b/src/org/iguana/iggy/gen/IggyParseTree.java
@@ -229,25 +229,6 @@ public class IggyParseTree {
         }
     }
 
-    // Alternative = label:Label?
-    public static class EmptyAlternative extends Alternative {
-        public EmptyAlternative(RuntimeRule rule, List<ParseTreeNode> children, int start, int end) {
-            super(rule, children, start, end);
-        }
-
-        public OptionNode label() {
-           return (OptionNode) childAt(0);
-        }
-
-        @Override
-        public <T> T accept(ParseTreeVisitor<T> visitor) {
-            if (visitor instanceof IggyParseTreeVisitor) {
-                return ((IggyParseTreeVisitor<T>) visitor).visitEmptyAlternative(this);
-            }
-            return visitor.visitNonterminalNode(this);
-        }
-    }
-
     public static abstract class Sequence extends NonterminalNode {
         public Sequence(RuntimeRule rule, List<ParseTreeNode> children, int start, int end) {
             super(rule, children, start, end);
@@ -320,6 +301,25 @@ public class IggyParseTree {
         public <T> T accept(ParseTreeVisitor<T> visitor) {
             if (visitor instanceof IggyParseTreeVisitor) {
                 return ((IggyParseTreeVisitor<T>) visitor).visitSingleElemSequence(this);
+            }
+            return visitor.visitNonterminalNode(this);
+        }
+    }
+
+    // Sequence = label:Label?
+    public static class EmptySequence extends Sequence {
+        public EmptySequence(RuntimeRule rule, List<ParseTreeNode> children, int start, int end) {
+            super(rule, children, start, end);
+        }
+
+        public OptionNode label() {
+           return (OptionNode) childAt(0);
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<T> visitor) {
+            if (visitor instanceof IggyParseTreeVisitor) {
+                return ((IggyParseTreeVisitor<T>) visitor).visitEmptySequence(this);
             }
             return visitor.visitNonterminalNode(this);
         }

--- a/src/org/iguana/iggy/gen/IggyParseTreeBuilder.java
+++ b/src/org/iguana/iggy/gen/IggyParseTreeBuilder.java
@@ -48,8 +48,6 @@ public class IggyParseTreeBuilder extends DefaultParseTreeBuilder {
                         return new IggyParseTree.SequenceAlternative(rule, children, leftExtent, rightExtent);
                     case "Associativity":
                         return new IggyParseTree.AssociativityAlternative(rule, children, leftExtent, rightExtent);
-                    case "Empty":
-                        return new IggyParseTree.EmptyAlternative(rule, children, leftExtent, rightExtent);
                     default:
                         throw new RuntimeException("Unexpected label:" + label);
                 }
@@ -59,6 +57,8 @@ public class IggyParseTreeBuilder extends DefaultParseTreeBuilder {
                         return new IggyParseTree.MoreThanOneElemSequence(rule, children, leftExtent, rightExtent);
                     case "SingleElem":
                         return new IggyParseTree.SingleElemSequence(rule, children, leftExtent, rightExtent);
+                    case "Empty":
+                        return new IggyParseTree.EmptySequence(rule, children, leftExtent, rightExtent);
                     default:
                         throw new RuntimeException("Unexpected label:" + label);
                 }

--- a/src/org/iguana/iggy/gen/IggyParseTreeVisitor.java
+++ b/src/org/iguana/iggy/gen/IggyParseTreeVisitor.java
@@ -31,11 +31,11 @@ public interface IggyParseTreeVisitor<T> extends ParseTreeVisitor<T> {
 
     T visitAssociativityAlternative(IggyParseTree.AssociativityAlternative node);
 
-    T visitEmptyAlternative(IggyParseTree.EmptyAlternative node);
-
     T visitMoreThanOneElemSequence(IggyParseTree.MoreThanOneElemSequence node);
 
     T visitSingleElemSequence(IggyParseTree.SingleElemSequence node);
+
+    T visitEmptySequence(IggyParseTree.EmptySequence node);
 
     T visitCondition(IggyParseTree.Condition node);
 

--- a/src/org/iguana/iggy/gen/IggyParser.java
+++ b/src/org/iguana/iggy/gen/IggyParser.java
@@ -13,8 +13,6 @@ public class IggyParser extends IguanaParser {
         super(grammar);
     }
 
-    private static final String grammarName = "iggy";
-
     private static IggyParser parser;
 
     public static IggyParser getInstance() {

--- a/src/org/iguana/iggy/gen/iggy.json
+++ b/src/org/iguana/iggy/gen/iggy.json
@@ -783,25 +783,6 @@
                 }
               ],
               "associativity" : "UNDEFINED"
-            },
-            {
-              "seqs" : [
-                {
-                  "symbols" : [
-                    {
-                      "kind" : "Opt",
-                      "name" : "Label?",
-                      "label" : "label",
-                      "s" : {
-                        "kind" : "Identifier",
-                        "name" : "Label"
-                      }
-                    }
-                  ],
-                  "label" : "Empty"
-                }
-              ],
-              "associativity" : "UNDEFINED"
             }
           ]
         }
@@ -916,6 +897,25 @@
                   ],
                   "associativity" : "UNDEFINED",
                   "label" : "SingleElem"
+                }
+              ],
+              "associativity" : "UNDEFINED"
+            },
+            {
+              "seqs" : [
+                {
+                  "symbols" : [
+                    {
+                      "kind" : "Opt",
+                      "name" : "Label?",
+                      "label" : "label",
+                      "s" : {
+                        "kind" : "Identifier",
+                        "name" : "Label"
+                      }
+                    }
+                  ],
+                  "label" : "Empty"
                 }
               ],
               "associativity" : "UNDEFINED"

--- a/src/org/iguana/parser/IguanaParser.java
+++ b/src/org/iguana/parser/IguanaParser.java
@@ -49,46 +49,42 @@ public class IguanaParser extends IguanaRecognizer {
     private Input input;
 
     public IguanaParser(Grammar grammar) {
-        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
+        this(grammar, Configuration.load());
     }
 
-    public IguanaParser(Grammar grammar, Nonterminal start) {
-        this(grammar, start, Configuration.load());
-    }
-
-    public IguanaParser(Grammar grammar, Nonterminal start, Configuration config) {
-        super(grammar, start, config);
+    public IguanaParser(Grammar grammar, Configuration config) {
+        super(grammar, config);
     }
 
     public IguanaParser(RuntimeGrammar grammar) {
-        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
+        this(grammar, Configuration.load());
     }
 
-    public IguanaParser(RuntimeGrammar grammar, Nonterminal start) {
-        this(grammar, start, Configuration.load());
-    }
-
-    public IguanaParser(RuntimeGrammar grammar, Nonterminal start, Configuration config) {
-        super(grammar, start, config);
+    public IguanaParser(RuntimeGrammar grammar, Configuration config) {
+        super(grammar, config);
     }
 
     public void parse(Input input) {
-        parse(input, new ParseOptions.Builder().setGlobal(false).build());
+        parse(input, Nonterminal.withName(assertStartSymbolNotNull(start).getName()), new ParseOptions.Builder().setGlobal(false).build());
     }
 
-    public void parse(Input input, ParseOptions options) {
+    public void parse(Input input, Nonterminal start) {
+        parse(input, start, new ParseOptions.Builder().setGlobal(false).build());
+    }
+
+    public void parse(Input input, Nonterminal start, ParseOptions options) {
         clear();
         this.input = input;
         IguanaRuntime<?> runtime = new IguanaRuntime<>(config, parserResultOps);
-        long start = System.nanoTime();
-        this.sppf = (NonterminalNode) runtime.run(input, grammarGraph, options.getMap(), options.isGlobal());
-        long end = System.nanoTime();
+        long startTime = System.nanoTime();
+        this.sppf = (NonterminalNode) runtime.run(input, start, grammarGraph, options.getMap(), options.isGlobal());
+        long endTime = System.nanoTime();
         this.statistics = runtime.getStatistics();
         this.parseError = runtime.getParseError();
         if (parseError != null) {
             throw new ParseErrorException(parseError);
         } else {
-            System.out.println("Parsing finished in " + (end - start) / 1000_000 + "ms.");
+            System.out.println("Parsing finished in " + (endTime - startTime) / 1000_000 + "ms.");
         }
     }
 

--- a/src/org/iguana/parser/IguanaParser.java
+++ b/src/org/iguana/parser/IguanaParser.java
@@ -118,9 +118,9 @@ public class IguanaParser extends IguanaRecognizer {
             return node;
         }
 
-        DefaultSPPFToParseTreeVisitor<?> converter = new DefaultSPPFToParseTreeVisitor<>(getParseTreeBuilder(input), input, ignoreLayout, parserResultOps);
+        DefaultSPPFToParseTreeVisitor<ParseTreeNode> visitor = new DefaultSPPFToParseTreeVisitor<>(getParseTreeBuilder(input), input, ignoreLayout, parserResultOps);
         long start = System.nanoTime();
-        this.parseTree = (ParseTreeNode) converter.convertNonterminalNode(sppf);
+        this.parseTree = sppf.accept(visitor);
         long end = System.nanoTime();
         System.out.println("Parse tree creation finished in " + (end - start) / 1000_000 + "ms.");
 

--- a/src/org/iguana/parser/IguanaParser.java
+++ b/src/org/iguana/parser/IguanaParser.java
@@ -29,6 +29,7 @@ package org.iguana.parser;
 
 import org.iguana.grammar.Grammar;
 import org.iguana.grammar.runtime.RuntimeGrammar;
+import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.parsetree.DefaultParseTreeBuilder;
 import org.iguana.parsetree.ParseTreeBuilder;
 import org.iguana.parsetree.ParseTreeNode;
@@ -48,19 +49,27 @@ public class IguanaParser extends IguanaRecognizer {
     private Input input;
 
     public IguanaParser(Grammar grammar) {
-        this(grammar, grammar.getStartSymbol().getStartSymbol(), Configuration.load());
+        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
     }
 
-    public IguanaParser(Grammar grammar, String startNonterminal, Configuration config) {
-        super(grammar, startNonterminal, config);
+    public IguanaParser(Grammar grammar, Nonterminal start) {
+        this(grammar, start, Configuration.load());
     }
 
-    public IguanaParser(RuntimeGrammar grammar, Configuration config) {
-        super(grammar, config);
+    public IguanaParser(Grammar grammar, Nonterminal start, Configuration config) {
+        super(grammar, start, config);
     }
 
     public IguanaParser(RuntimeGrammar grammar) {
-        super(grammar, Configuration.load());
+        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
+    }
+
+    public IguanaParser(RuntimeGrammar grammar, Nonterminal start) {
+        this(grammar, start, Configuration.load());
+    }
+
+    public IguanaParser(RuntimeGrammar grammar, Nonterminal start, Configuration config) {
+        super(grammar, start, config);
     }
 
     public void parse(Input input) {

--- a/src/org/iguana/parser/IguanaParser.java
+++ b/src/org/iguana/parser/IguanaParser.java
@@ -104,12 +104,12 @@ public class IguanaParser extends IguanaRecognizer {
         return getParseTree(false, true);
     }
 
-    public ParseTreeNode getParseTree(boolean allowAmbigities, boolean ignoreLayout) {
+    public ParseTreeNode getParseTree(boolean allowAmbiguities, boolean ignoreLayout) {
         if (parseTree != null) return parseTree;
 
         if (sppf == null) return null;
 
-        if (allowAmbigities) {
+        if (allowAmbiguities) {
             AmbiguousSPPFToParseTreeVisitor<ParseTreeNode> visitor = new AmbiguousSPPFToParseTreeVisitor<>(getParseTreeBuilder(input), ignoreLayout, parserResultOps);
             long start = System.nanoTime();
             ParseTreeNode node = (ParseTreeNode) sppf.accept(visitor).getValues().get(0);

--- a/src/org/iguana/parser/IguanaRecognizer.java
+++ b/src/org/iguana/parser/IguanaRecognizer.java
@@ -24,32 +24,34 @@ public class IguanaRecognizer {
 
     protected ParseError parseError;
     protected RecognizerStatistics statistics;
+    protected final Start start;
 
     public IguanaRecognizer(Grammar grammar) {
-        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
+        this(grammar, Configuration.load());
     }
 
-    public IguanaRecognizer(Grammar grammar, Nonterminal start, Configuration config) {
-        this(GrammarTransformer.transform(grammar.toRuntimeGrammar()), start, config);
+    public IguanaRecognizer(Grammar grammar, Configuration config) {
+        this(GrammarTransformer.transform(grammar.toRuntimeGrammar()), config);
     }
 
     public IguanaRecognizer(RuntimeGrammar grammar) {
-        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
+        this(grammar, Configuration.load());
     }
 
-    public IguanaRecognizer(RuntimeGrammar grammar, Nonterminal start, Configuration config) {
-        this.grammarGraph = GrammarGraphBuilder.from(grammar, start, config);
+    public IguanaRecognizer(RuntimeGrammar grammar, Configuration config) {
+        this.grammarGraph = GrammarGraphBuilder.from(grammar, config);
         this.config = config;
+        start = grammar.getStartSymbol();
     }
 
     public boolean recognize(Input input) {
-        return recognize(input, Collections.emptyMap(), false);
+        return recognize(input, Nonterminal.withName(assertStartSymbolNotNull(start).getName()), Collections.emptyMap(), false);
     }
 
-    public boolean recognize(Input input,  Map<String, Object> map, boolean global) {
+    public boolean recognize(Input input, Nonterminal start, Map<String, Object> map, boolean global) {
         clear();
         IguanaRuntime<RecognizerResult> runtime = new IguanaRuntime<>(config, recognizerResultOps);
-        RecognizerResult root = (RecognizerResult) runtime.run(input, grammarGraph, map, global);
+        RecognizerResult root = (RecognizerResult) runtime.run(input, start, grammarGraph, map, global);
         this.parseError = runtime.getParseError();
         this.statistics = runtime.getStatistics();
         if (root == null) return false;

--- a/src/org/iguana/parser/IguanaRecognizer.java
+++ b/src/org/iguana/parser/IguanaRecognizer.java
@@ -26,6 +26,8 @@ public class IguanaRecognizer {
     protected RecognizerStatistics statistics;
     protected final Start start;
 
+    protected final RuntimeGrammar finalGrammar;
+
     public IguanaRecognizer(Grammar grammar) {
         this(grammar, Configuration.load());
     }
@@ -41,7 +43,8 @@ public class IguanaRecognizer {
     public IguanaRecognizer(RuntimeGrammar grammar, Configuration config) {
         this.grammarGraph = GrammarGraphBuilder.from(grammar, config);
         this.config = config;
-        start = grammar.getStartSymbol();
+        this.start = grammar.getStartSymbol();
+        this.finalGrammar = grammar;
     }
 
     public boolean recognize(Input input) {
@@ -64,6 +67,10 @@ public class IguanaRecognizer {
 
     public ParseError getParseError() {
         return parseError;
+    }
+
+    public RuntimeGrammar getFinalGrammar() {
+        return finalGrammar;
     }
 
     protected void clear() {

--- a/src/org/iguana/parser/IguanaRecognizer.java
+++ b/src/org/iguana/parser/IguanaRecognizer.java
@@ -1,14 +1,16 @@
 package org.iguana.parser;
 
-import org.iguana.utils.input.Input;
 import org.iguana.grammar.Grammar;
 import org.iguana.grammar.GrammarGraph;
 import org.iguana.grammar.GrammarGraphBuilder;
 import org.iguana.grammar.runtime.RuntimeGrammar;
+import org.iguana.grammar.symbol.Nonterminal;
+import org.iguana.grammar.symbol.Start;
 import org.iguana.grammar.transformation.GrammarTransformer;
 import org.iguana.result.RecognizerResult;
 import org.iguana.result.RecognizerResultOps;
 import org.iguana.util.Configuration;
+import org.iguana.utils.input.Input;
 
 import java.util.Collections;
 import java.util.Map;
@@ -24,19 +26,19 @@ public class IguanaRecognizer {
     protected RecognizerStatistics statistics;
 
     public IguanaRecognizer(Grammar grammar) {
-        this(grammar, grammar.getStartSymbol().getStartSymbol(), Configuration.load());
+        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
     }
 
-    public IguanaRecognizer(Grammar grammar, String startNonterminal, Configuration config) {
-        this(GrammarTransformer.transform(grammar.toRuntimeGrammar(), startNonterminal), config);
+    public IguanaRecognizer(Grammar grammar, Nonterminal start, Configuration config) {
+        this(GrammarTransformer.transform(grammar.toRuntimeGrammar()), start, config);
     }
 
     public IguanaRecognizer(RuntimeGrammar grammar) {
-        this(grammar, Configuration.load());
+        this(grammar, Nonterminal.withName(assertStartSymbolNotNull(grammar.getStartSymbol()).getName()), Configuration.load());
     }
 
-    public IguanaRecognizer(RuntimeGrammar grammar, Configuration config) {
-        this.grammarGraph = GrammarGraphBuilder.from(grammar, config);
+    public IguanaRecognizer(RuntimeGrammar grammar, Nonterminal start, Configuration config) {
+        this.grammarGraph = GrammarGraphBuilder.from(grammar, start, config);
         this.config = config;
     }
 
@@ -62,13 +64,16 @@ public class IguanaRecognizer {
         return parseError;
     }
 
-    public boolean hasParseError() {
-        return parseError != null;
-    }
-
     protected void clear() {
         grammarGraph.clear();
         parseError = null;
         statistics = null;
+    }
+
+    protected static Start assertStartSymbolNotNull(Start start) {
+        if (start == null) {
+            throw new RuntimeException("Start symbol is not set");
+        }
+        return start;
     }
 }

--- a/src/org/iguana/parser/IguanaRuntime.java
+++ b/src/org/iguana/parser/IguanaRuntime.java
@@ -1,5 +1,6 @@
 package org.iguana.parser;
 
+import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.utils.input.Input;
 import org.iguana.datadependent.ast.Expression;
 import org.iguana.datadependent.ast.Statement;
@@ -60,7 +61,7 @@ public class IguanaRuntime<T extends Result> {
         this.ctx = GLLEvaluator.getEvaluatorContext(config);
     }
 
-    public Result run(Input input, GrammarGraph grammarGraph, Map<String, Object> map, boolean global) {
+    public Result run(Input input, Nonterminal start, GrammarGraph grammarGraph, Map<String, Object> map, boolean global) {
         this.input = input;
 
         IEvaluatorContext ctx = getEvaluatorContext();
@@ -68,7 +69,7 @@ public class IguanaRuntime<T extends Result> {
         if (global)
             map.forEach(ctx::declareGlobalVariable);
 
-        NonterminalGrammarSlot startSymbol = grammarGraph.getStartSlot();
+        NonterminalGrammarSlot startSymbol = grammarGraph.getStartSlot(start);
 
         int inputLength = input.length() - 1;
 

--- a/src/org/iguana/parsetree/DefaultParseTreeBuilder.java
+++ b/src/org/iguana/parsetree/DefaultParseTreeBuilder.java
@@ -38,24 +38,32 @@ public class DefaultParseTreeBuilder implements ParseTreeBuilder<ParseTreeNode> 
     }
 
     @Override
-    public MetaSymbolNode metaSymbolNode(Symbol symbol, List<ParseTreeNode> children, int leftExtent, int rightExtent) {
-        MetaSymbolNode node;
-        if (symbol instanceof Star) {
-            node = new StarNode(symbol, children, leftExtent, rightExtent);
-        } else if (symbol instanceof Plus) {
-            node = new PlusNode(symbol, children, leftExtent, rightExtent);
-        } else if (symbol instanceof Group) {
-            node = new GroupNode(symbol, children, leftExtent, rightExtent);
-        } else if (symbol instanceof Alt) {
-            node = new AltNode(symbol, children.get(0), leftExtent, rightExtent);
-        } else if (symbol instanceof Opt) {
-            node = new OptionNode(symbol, children.isEmpty() ? null : children.get(0), leftExtent, rightExtent);
-        } else if (symbol instanceof Start) {
-            node = new StartNode(symbol, children, leftExtent, rightExtent);
-        } else {
-            throw new RuntimeException("Unknown meta symbol type: " + symbol);
-        }
+    public ParseTreeNode starNode(Star symbol, List<ParseTreeNode> children, int leftExtent, int rightExtent) {
+        return new StarNode(symbol, children, leftExtent, rightExtent);
+    }
 
-        return node;
+    @Override
+    public ParseTreeNode plusNode(Plus symbol, List<ParseTreeNode> children, int leftExtent, int rightExtent) {
+        return new PlusNode(symbol, children, leftExtent, rightExtent);
+    }
+
+    @Override
+    public ParseTreeNode optNode(Opt symbol, ParseTreeNode child, int leftExtent, int rightExtent) {
+        return new OptionNode(symbol,child, leftExtent, rightExtent);
+    }
+
+    @Override
+    public ParseTreeNode altNode(Alt symbol, ParseTreeNode child, int leftExtent, int rightExtent) {
+        return new AltNode(symbol, child, leftExtent, rightExtent);
+    }
+
+    @Override
+    public ParseTreeNode groupNode(Group symbol, List<ParseTreeNode> children, int leftExtent, int rightExtent) {
+        return new GroupNode(symbol, children, leftExtent, rightExtent);
+    }
+
+    @Override
+    public ParseTreeNode startNode(Start symbol, List<ParseTreeNode> children, int leftExtent, int rightExtent) {
+        return new StartNode(symbol, children, leftExtent, rightExtent);
     }
 }

--- a/src/org/iguana/parsetree/DefaultParseTreeBuilder.java
+++ b/src/org/iguana/parsetree/DefaultParseTreeBuilder.java
@@ -58,9 +58,4 @@ public class DefaultParseTreeBuilder implements ParseTreeBuilder<ParseTreeNode> 
 
         return node;
     }
-
-    @Override
-    public List<ParseTreeNode> getChildren(ParseTreeNode node) {
-        return node.children();
-    }
 }

--- a/src/org/iguana/parsetree/MetaSymbolNode.java
+++ b/src/org/iguana/parsetree/MetaSymbolNode.java
@@ -1,6 +1,6 @@
 package org.iguana.parsetree;
 
-import org.iguana.grammar.symbol.Symbol;
+import org.iguana.grammar.symbol.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -112,7 +112,7 @@ public abstract class MetaSymbolNode implements ParseTreeNode {
     }
 
     public static class StarNode extends MultiChildMetaSymbolNode {
-        public StarNode(Symbol symbol, List<ParseTreeNode> children, int start, int end) {
+        public StarNode(Star symbol, List<ParseTreeNode> children, int start, int end) {
             super(symbol, children, start, end);
         }
 
@@ -123,7 +123,7 @@ public abstract class MetaSymbolNode implements ParseTreeNode {
     }
 
     public static class PlusNode extends MultiChildMetaSymbolNode {
-        public PlusNode(Symbol symbol, List<ParseTreeNode> children, int start, int end) {
+        public PlusNode(Plus symbol, List<ParseTreeNode> children, int start, int end) {
             super(symbol, children, start, end);
         }
 
@@ -134,7 +134,7 @@ public abstract class MetaSymbolNode implements ParseTreeNode {
     }
 
     public static class GroupNode extends MultiChildMetaSymbolNode {
-        public GroupNode(Symbol symbol, List<ParseTreeNode> children, int start, int end) {
+        public GroupNode(Group symbol, List<ParseTreeNode> children, int start, int end) {
             super(symbol, children, start, end);
         }
 
@@ -145,7 +145,7 @@ public abstract class MetaSymbolNode implements ParseTreeNode {
     }
 
     public static class OptionNode extends SingleChildMetaSymbolNode {
-        public OptionNode(Symbol symbol, ParseTreeNode child, int start, int end) {
+        public OptionNode(Opt symbol, ParseTreeNode child, int start, int end) {
             super(symbol, child, start, end);
         }
 
@@ -156,7 +156,7 @@ public abstract class MetaSymbolNode implements ParseTreeNode {
     }
 
     public static class AltNode extends SingleChildMetaSymbolNode {
-        public AltNode(Symbol symbol, ParseTreeNode child, int start, int end) {
+        public AltNode(Alt symbol, ParseTreeNode child, int start, int end) {
             super(symbol, child, start, end);
         }
 
@@ -167,7 +167,7 @@ public abstract class MetaSymbolNode implements ParseTreeNode {
     }
 
     public static class StartNode extends MultiChildMetaSymbolNode {
-        public StartNode(Symbol symbol, List<ParseTreeNode> children, int start, int end) {
+        public StartNode(Start symbol, List<ParseTreeNode> children, int start, int end) {
             super(symbol, children, start, end);
         }
 

--- a/src/org/iguana/parsetree/ParseTreeBuilder.java
+++ b/src/org/iguana/parsetree/ParseTreeBuilder.java
@@ -12,5 +12,4 @@ public interface ParseTreeBuilder<T> {
     T nonterminalNode(RuntimeRule rule, List<T> children, int leftExtent, int rightExtent);
     T ambiguityNode(Set<T> node);
     T metaSymbolNode(Symbol symbol, List<T> children, int leftExtent, int rightExtent);
-    List<T> getChildren(T node);
 }

--- a/src/org/iguana/parsetree/ParseTreeBuilder.java
+++ b/src/org/iguana/parsetree/ParseTreeBuilder.java
@@ -1,15 +1,49 @@
 package org.iguana.parsetree;
 
 import org.iguana.grammar.runtime.RuntimeRule;
-import org.iguana.grammar.symbol.Symbol;
-import org.iguana.grammar.symbol.Terminal;
+import org.iguana.grammar.symbol.*;
 
 import java.util.List;
 import java.util.Set;
 
 public interface ParseTreeBuilder<T> {
     T terminalNode(Terminal terminal, int leftExtent, int rightExtent);
+
     T nonterminalNode(RuntimeRule rule, List<T> children, int leftExtent, int rightExtent);
+
     T ambiguityNode(Set<T> node);
-    T metaSymbolNode(Symbol symbol, List<T> children, int leftExtent, int rightExtent);
+
+    T starNode(Star symbol, List<T> children, int leftExtent, int rightExtent);
+
+    T plusNode(Plus symbol, List<T> children, int leftExtent, int rightExtent);
+
+    T optNode(Opt symbol, T child, int leftExtent, int rightExtent);
+
+    T altNode(Alt symbol, T child, int leftExtent, int rightExtent);
+
+    T groupNode(Group symbol, List<T> children, int leftExtent, int rightExtent);
+
+    T startNode(Start symbol, List<T> children, int leftExtent, int rightExtent);
+
+    default T metaSymbolNode(Symbol symbol, List<T> children, int leftExtent, int rightExtent) {
+        if (symbol instanceof Star) {
+            return starNode((Star) symbol, children, leftExtent, rightExtent);
+        }
+        if (symbol instanceof Plus) {
+            return plusNode((Plus) symbol, children, leftExtent, rightExtent);
+        }
+        if (symbol instanceof Group) {
+            return groupNode((Group) symbol, children, leftExtent, rightExtent);
+        }
+        if (symbol instanceof Alt) {
+            return altNode((Alt) symbol, children.get(0), leftExtent, rightExtent);
+        }
+        if (symbol instanceof Opt) {
+            return optNode((Opt) symbol, children.isEmpty() ? null : children.get(0), leftExtent, rightExtent);
+        }
+        if (symbol instanceof Start) {
+            return startNode((Start) symbol, children, leftExtent, rightExtent);
+        }
+        throw new RuntimeException("Unknown meta symbol type: " + symbol);
+    }
 }

--- a/src/org/iguana/parsetree/VisitResult.java
+++ b/src/org/iguana/parsetree/VisitResult.java
@@ -9,7 +9,7 @@ import java.util.*;
 
 public abstract class VisitResult {
 
-    public abstract MergeResultVisitor<VisitResult> visitor();
+    public abstract MergeResultVisitor visitor();
     public abstract VisitResult merge(VisitResult other);
     public abstract <T> T accept(CreateNodeVisitor<T> visitor, PackedNode packedNode);
     public abstract java.util.List<Object> getValues();
@@ -24,10 +24,6 @@ public abstract class VisitResult {
 
     public static List list(java.util.List<Object> values) {
         return new VisitResult.List(values);
-    }
-
-    public static ListOfResult listOfResult(java.util.List<VisitResult> values) {
-        return new ListOfResult(values);
     }
 
     public static EBNF ebnf(java.util.List<Object> values, Symbol symbol) {
@@ -75,7 +71,7 @@ public abstract class VisitResult {
         }
 
         public VisitResult merge(VisitResult other) {
-            return other.visitor().visit(this);
+            return (VisitResult) other.visitor().visit(this);
         }
 
         @Override
@@ -121,7 +117,7 @@ public abstract class VisitResult {
         }
 
         public VisitResult merge(VisitResult other) {
-            return other.visitor().visit(this);
+            return (VisitResult) other.visitor().visit(this);
         }
 
         @Override
@@ -159,7 +155,7 @@ public abstract class VisitResult {
         }
 
         public VisitResult merge(VisitResult other) {
-            return other.visitor().visit(this);
+            return (VisitResult) other.visitor().visit(this);
         }
 
         @Override
@@ -210,7 +206,7 @@ public abstract class VisitResult {
 
         @Override
         public VisitResult merge(VisitResult other) {
-            return other.visitor().visit(this);
+            return (VisitResult) other.visitor().visit(this);
         }
 
         @Override
@@ -241,15 +237,15 @@ public abstract class VisitResult {
         }
     }
 
-    interface MergeResultVisitor<T> {
-        T visit(Empty other);
-        T visit(Single other);
-        T visit(List other);
-        T visit(EBNF other);
-        T visit(ListOfResult other);
+    interface MergeResultVisitor {
+        Object visit(Empty other);
+        Object visit(Single other);
+        Object visit(List other);
+        Object visit(EBNF other);
+        Object visit(ListOfResult other);
     }
 
-    class SingleVisitor implements MergeResultVisitor<VisitResult> {
+    class SingleVisitor implements MergeResultVisitor {
 
         private Single result;
 
@@ -298,7 +294,7 @@ public abstract class VisitResult {
         }
     }
 
-    class ListVisitor implements MergeResultVisitor<VisitResult> {
+    class ListVisitor implements MergeResultVisitor {
 
         private List result;
 
@@ -338,7 +334,7 @@ public abstract class VisitResult {
         }
     }
 
-    class EBNFResultVisitor implements MergeResultVisitor<VisitResult> {
+    class EBNFResultVisitor implements MergeResultVisitor {
 
         private EBNF result;
 
@@ -378,7 +374,7 @@ public abstract class VisitResult {
         }
     }
 
-    class ListOfResultVisitor implements MergeResultVisitor<VisitResult> {
+    class ListOfResultVisitor implements MergeResultVisitor {
 
         private ListOfResult result;
 
@@ -434,7 +430,7 @@ public abstract class VisitResult {
         }
     }
 
-    class EmptyVisitor implements MergeResultVisitor<VisitResult> {
+    class EmptyVisitor implements MergeResultVisitor {
 
         @Override
         public VisitResult visit(Empty other) {

--- a/src/org/iguana/parsetree/VisitResult.java
+++ b/src/org/iguana/parsetree/VisitResult.java
@@ -505,7 +505,6 @@ public abstract class VisitResult {
         public java.util.List<T> visit(EBNF result, PackedNode packedNode) {
             T ebnfNode = parseTreeBuilder.metaSymbolNode(result.getSymbol(), (java.util.List<T>) result.getValues(), packedNode.getLeftExtent(), packedNode.getRightExtent());
             return CollectionsUtil.list(ebnfNode);
-
         }
 
         @Override

--- a/src/org/iguana/result/ParserResultOps.java
+++ b/src/org/iguana/result/ParserResultOps.java
@@ -37,7 +37,7 @@ public class ParserResultOps implements ResultOps<NonPackedNode> {
         }
 
         @Override
-        public <R> R accept(SPPFVisitor<R> visitAction) { throw new UnsupportedOperationException(); }
+        public <R> R accept(SPPFVisitor<R> visitor) { throw new UnsupportedOperationException(); }
 
         @Override
         public void setAmbiguous(boolean ambiguous) {

--- a/src/org/iguana/sppf/IntermediateNode.java
+++ b/src/org/iguana/sppf/IntermediateNode.java
@@ -48,7 +48,7 @@ public class IntermediateNode extends NonPackedNode {
 
     @Override
     public <R> R accept(SPPFVisitor<R> visitor) {
-        return visitor.visit(this);
+        return (R) visitor.visit(this);
     }
 
     @Override

--- a/src/org/iguana/sppf/IntermediateNode.java
+++ b/src/org/iguana/sppf/IntermediateNode.java
@@ -47,8 +47,8 @@ public class IntermediateNode extends NonPackedNode {
     }
 
     @Override
-    public <R> R accept(SPPFVisitor<R> visitAction) {
-        return visitAction.visit(this);
+    public <R> R accept(SPPFVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/org/iguana/sppf/NonterminalNode.java
+++ b/src/org/iguana/sppf/NonterminalNode.java
@@ -78,8 +78,8 @@ public class NonterminalNode extends NonPackedNode {
     }
 
 	@Override
-	public <R> R accept(SPPFVisitor<R> visitAction) {
-		return visitAction.visit(this);
+	public <R> R accept(SPPFVisitor<R> visitor) {
+		return visitor.visit(this);
 	}
 
     @Override

--- a/src/org/iguana/sppf/PackedNode.java
+++ b/src/org/iguana/sppf/PackedNode.java
@@ -86,7 +86,7 @@ public class PackedNode implements SPPFNode {
 
     @Override
     public <R> R accept(SPPFVisitor<R> visitor) {
-        return visitor.visit(this);
+        return (R) visitor.visit(this);
     }
 
     public NonPackedNode getLeftChild() {

--- a/src/org/iguana/sppf/PackedNode.java
+++ b/src/org/iguana/sppf/PackedNode.java
@@ -85,8 +85,8 @@ public class PackedNode implements SPPFNode {
     }
 
     @Override
-    public <R> R accept(SPPFVisitor<R> visitAction) {
-        return visitAction.visit(this);
+    public <R> R accept(SPPFVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 
     public NonPackedNode getLeftChild() {

--- a/src/org/iguana/sppf/SPPFNode.java
+++ b/src/org/iguana/sppf/SPPFNode.java
@@ -43,10 +43,11 @@ public interface SPPFNode extends Result {
 
 	int getLeftExtent();
 
-	<R> R accept(SPPFVisitor<R> visitAction);
+	<R> R accept(SPPFVisitor<R> visitor);
 
 	default Object getValue() {
 		return null;
 	}
+	
 	default boolean isDummy() { return false; }
 }

--- a/src/org/iguana/sppf/TerminalNode.java
+++ b/src/org/iguana/sppf/TerminalNode.java
@@ -39,8 +39,8 @@ public abstract class TerminalNode extends NonPackedNode {
 	}
 
 	@Override
-	public <R> R accept(SPPFVisitor<R> visitAction) {
-		return visitAction.visit(this);
+	public <R> R accept(SPPFVisitor<R> visitor) {
+		return visitor.visit(this);
 	}
 
 	@Override

--- a/src/org/iguana/traversal/SPPFVisitor.java
+++ b/src/org/iguana/traversal/SPPFVisitor.java
@@ -46,8 +46,8 @@ public interface SPPFVisitor<T> {
 
 	T visit(NonterminalNode node);
 
-	T visit(IntermediateNode node);
+	Object visit(IntermediateNode node);
 
-	T visit(PackedNode node);
+	Object visit(PackedNode node);
 
 }

--- a/src/org/iguana/traversal/idea/GenerateElements.java
+++ b/src/org/iguana/traversal/idea/GenerateElements.java
@@ -54,8 +54,6 @@ public class GenerateElements {
         Map<String, Set<String>> elements = new LinkedHashMap<>();
         for (RuntimeRule rule : rules) {
 
-            if (rule.getHead().getName().equals("$default$")) continue;
-
             Set<String> labels = elements.get(rule.getHead().getName());
             if (labels == null) {
                 labels = new HashSet<>();
@@ -146,9 +144,6 @@ public class GenerateElements {
         Map<String, Map<String, Map<String, NUM>>> elements = new LinkedHashMap<>();
 
         for (RuntimeRule rule : rules) {
-
-            if (rule.getHead().getName().equals("$default$")) continue;
-
             Map<String, Map<String, NUM>> m1 = elements.get(rule.getHead().getName());
             if (m1 == null) {
                 m1 = new LinkedHashMap<>();

--- a/src/org/iguana/traversal/idea/Names.java
+++ b/src/org/iguana/traversal/idea/Names.java
@@ -75,7 +75,7 @@ public class Names implements GrammarTransformation {
         }
 
         public RuntimeRule visitRule(RuntimeRule rule) {
-            RuntimeRule.Builder builder = rule.copyBuilder();
+            RuntimeRule.Builder builder = rule.copy();
             List<Symbol> symbols = new ArrayList<>();
             for (Symbol symbol : rule.getBody())
                 symbols.add(visitSymbol(symbol));

--- a/src/org/iguana/util/serialization/JsonSerializer.java
+++ b/src/org/iguana/util/serialization/JsonSerializer.java
@@ -274,7 +274,10 @@ public class JsonSerializer {
     }
 
     @JsonDeserialize(builder = Rule.Builder.class)
-    abstract static class RuleMixIn { }
+    abstract static class RuleMixIn {
+        @JsonIgnore
+        Map<String, Object> attributes;
+    }
 
     abstract static class AnnotationMixIn {
         @JsonCreator
@@ -291,7 +294,10 @@ public class JsonSerializer {
     abstract static class AlternativeMixIn { }
 
     @JsonDeserialize(builder = Sequence.Builder.class)
-    abstract static class SequenceMixIn { }
+    abstract static class SequenceMixIn {
+        @JsonIgnore
+        Map<String, Object> attributes;
+    }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
     @JsonSubTypes({

--- a/src/org/iguana/util/serialization/JsonSerializer.java
+++ b/src/org/iguana/util/serialization/JsonSerializer.java
@@ -381,7 +381,7 @@ public class JsonSerializer {
 
     abstract static class StarNodeMixIn {
         StarNodeMixIn(
-            @JsonProperty("symbol") Symbol symbol,
+            @JsonProperty("symbol") Star symbol,
             @JsonProperty("children") List<ParseTreeNode> children,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end) { }
@@ -389,7 +389,7 @@ public class JsonSerializer {
 
     abstract static class PlusNodeMixIn {
         PlusNodeMixIn(
-            @JsonProperty("symbol") Symbol symbol,
+            @JsonProperty("symbol") Plus symbol,
             @JsonProperty("children") List<ParseTreeNode> children,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end) { }
@@ -397,7 +397,7 @@ public class JsonSerializer {
 
     abstract static class GroupNodeMixIn {
         GroupNodeMixIn(
-            @JsonProperty("symbol") Symbol symbol,
+            @JsonProperty("symbol") Group symbol,
             @JsonProperty("children") List<ParseTreeNode> children,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end) { }
@@ -405,7 +405,7 @@ public class JsonSerializer {
 
     abstract static class OptionNodeMixIn {
         OptionNodeMixIn(
-            @JsonProperty("symbol") Symbol symbol,
+            @JsonProperty("symbol") Opt symbol,
             @JsonProperty("child") ParseTreeNode child,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end) { }
@@ -413,7 +413,7 @@ public class JsonSerializer {
 
     abstract static class AltNodeMixIn {
         AltNodeMixIn(
-            @JsonProperty("symbol") Symbol symbol,
+            @JsonProperty("symbol") Alt symbol,
             @JsonProperty("child") ParseTreeNode child,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end) { }
@@ -421,7 +421,7 @@ public class JsonSerializer {
 
     abstract static class StartNodeMixIn {
         StartNodeMixIn(
-            @JsonProperty("symbol") Symbol symbol,
+            @JsonProperty("symbol") Start symbol,
             @JsonProperty("children") List<ParseTreeNode> children,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end) { }

--- a/src/org/iguana/util/serialization/JsonSerializer.java
+++ b/src/org/iguana/util/serialization/JsonSerializer.java
@@ -263,6 +263,8 @@ public class JsonSerializer {
     abstract static class RuntimeRuleMixIn {
         @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = LayoutStrategyFilter.class)
         LayoutStrategy layoutStrategy;
+        @JsonIgnore
+        Map<String, Object> attributes;
     }
 
     @JsonDeserialize(builder = Grammar.Builder.class)

--- a/src/resources/Iguana.iggy
+++ b/src/resources/Iguana.iggy
@@ -27,11 +27,12 @@ PriorityLevels
 Alternative
   = seq:Sequence                                        %Sequence
   | assoc:Associativity "(" seqs: {Sequence "|"}+ ")"   %Associativity
-  | label:Label?                                        %Empty
 
 Sequence
   = assoc:Associativity? cond:Condition? first:Symbol rest:Symbol+ ret:ReturnExpression? label:Label?   %MoreThanOneElem
   | cond:Condition? sym:Symbol ret:ReturnExpression? label:Label?                                       %SingleElem
+  | label:Label?                                                                                        %Empty
+
 
 Condition
   = "{" {Expression ","}* "}" "?"

--- a/src/resources/Iguana.iggy
+++ b/src/resources/Iguana.iggy
@@ -33,7 +33,6 @@ Sequence
   | cond:Condition? sym:Symbol ret:ReturnExpression? label:Label?                                       %SingleElem
   | label:Label?                                                                                        %Empty
 
-
 Condition
   = "{" {Expression ","}* "}" "?"
 

--- a/test/org/iguana/GrammarTest.java
+++ b/test/org/iguana/GrammarTest.java
@@ -81,7 +81,7 @@ public class GrammarTest {
             assertEquals(jsonGrammar, grammar);
         }
 
-        RuntimeGrammar runtimeGrammar = GrammarTransformer.transform(grammar.toRuntimeGrammar(), grammar.getStartSymbol().getStartSymbol());
+        RuntimeGrammar runtimeGrammar = GrammarTransformer.transform(grammar.toRuntimeGrammar());
 
         String finalGrammarPath = test + "/final_grammar.json";
         if (REGENERATE_FILES || !Files.exists(Paths.get(finalGrammarPath))) {

--- a/test/org/iguana/GrammarTest.java
+++ b/test/org/iguana/GrammarTest.java
@@ -172,7 +172,7 @@ public class GrammarTest {
                 }
             } catch (AmbiguityException e) {
                 try {
-                    if (parser.getStatistics().getAmbiguousNodesCount() < 10) {
+                    if (parser.getStatistics().getAmbiguousNodesCount() < 20) {
                         actualParseTree = parser.getParseTree(true, true);
                         String pdfPath = testPath + "/tree" + j + ".pdf";
                         if (!Files.exists(Paths.get(pdfPath))) {

--- a/test/org/iguana/grammar/AttributesTest.java
+++ b/test/org/iguana/grammar/AttributesTest.java
@@ -1,0 +1,38 @@
+package org.iguana.grammar;
+
+import org.iguana.grammar.runtime.RuntimeGrammar;
+import org.iguana.grammar.runtime.RuntimeRule;
+import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.transformation.GrammarTransformer;
+import org.iguana.regex.Char;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AttributesTest {
+
+    @Test
+    public void testTransformationChainShouldKeepAttributes() {
+        // A = "a"
+        Rule.Builder ruleBuilder = new Rule.Builder(Nonterminal.withName("A"));
+        PriorityLevel.Builder priorityLevelBuilder = new PriorityLevel.Builder();
+        Alternative.Builder alternativeBuilder = new Alternative.Builder();
+        Sequence.Builder sequenceBuilder = new Sequence.Builder();
+        sequenceBuilder.addSymbol(Terminal.from(Char.from('a')));
+        sequenceBuilder.addAttribute("test", 123);
+        alternativeBuilder.addSequence(sequenceBuilder.build());
+        priorityLevelBuilder.addAlternative(alternativeBuilder.build());
+        ruleBuilder.addPriorityLevel(priorityLevelBuilder.build());
+        Rule rule = ruleBuilder.build();
+
+        Grammar.Builder grammarBuilder = new Grammar.Builder();
+        grammarBuilder.setStartSymbol(Start.from("A"));
+        grammarBuilder.addRule(rule);
+        Grammar grammar = grammarBuilder.build();
+
+        RuntimeGrammar result = GrammarTransformer.transform(grammar.toRuntimeGrammar());
+        RuntimeRule runtimeRule = result.getRules().get(0);
+
+        Assertions.assertTrue(runtimeRule.getAttributes().containsKey("test"));
+        Assertions.assertEquals(runtimeRule.getAttributes().get("test"), 123);
+    }
+}

--- a/test/org/iguana/gss/GSSNodeTest.java
+++ b/test/org/iguana/gss/GSSNodeTest.java
@@ -5,6 +5,7 @@ import org.iguana.grammar.GrammarGraphBuilder;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.slot.EndGrammarSlot;
 import org.iguana.grammar.slot.NonterminalGrammarSlot;
+import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.iggy.gen.IggyParser;
 import org.iguana.parser.IguanaRuntime;
 import org.iguana.result.ParserResultOps;
@@ -31,9 +32,9 @@ public class GSSNodeTest {
     @BeforeEach
     public void init() {
         RuntimeGrammar grammar = fromIggyGrammar(
-            "start A = 'a'").toRuntimeGrammar();
+            "A = 'a'").toRuntimeGrammar();
 
-        grammarGraph = GrammarGraphBuilder.from(grammar);
+        grammarGraph = GrammarGraphBuilder.from(grammar, Nonterminal.withName("A"));
         input = Input.fromString("Test");
     }
 

--- a/test/org/iguana/gss/GSSNodeTest.java
+++ b/test/org/iguana/gss/GSSNodeTest.java
@@ -5,8 +5,6 @@ import org.iguana.grammar.GrammarGraphBuilder;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.slot.EndGrammarSlot;
 import org.iguana.grammar.slot.NonterminalGrammarSlot;
-import org.iguana.grammar.symbol.Nonterminal;
-import org.iguana.iggy.gen.IggyParser;
 import org.iguana.parser.IguanaRuntime;
 import org.iguana.result.ParserResultOps;
 import org.iguana.sppf.DefaultTerminalNode;
@@ -34,7 +32,7 @@ public class GSSNodeTest {
         RuntimeGrammar grammar = fromIggyGrammar(
             "A = 'a'").toRuntimeGrammar();
 
-        grammarGraph = GrammarGraphBuilder.from(grammar, Nonterminal.withName("A"));
+        grammarGraph = GrammarGraphBuilder.from(grammar);
         input = Input.fromString("Test");
     }
 

--- a/test/org/iguana/parser/firstfollow/FirstFollowTest.java
+++ b/test/org/iguana/parser/firstfollow/FirstFollowTest.java
@@ -4,7 +4,6 @@ import org.iguana.grammar.operations.FirstFollowSets;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.grammar.transformation.GrammarTransformer;
-import org.iguana.iggy.gen.IggyParser;
 import org.iguana.regex.CharRange;
 import org.iguana.regex.EOF;
 import org.junit.jupiter.api.Test;

--- a/test/resources/grammars/basic/Test1/grammar.json
+++ b/test/resources/grammars/basic/Test1/grammar.json
@@ -9,6 +9,9 @@
         {
           "alternatives" : [
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/basic/Test11/grammar.json
+++ b/test/resources/grammars/basic/Test11/grammar.json
@@ -67,6 +67,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/basic/Test12/grammar.json
+++ b/test/resources/grammars/basic/Test12/grammar.json
@@ -45,6 +45,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/basic/Test16/grammar.json
+++ b/test/resources/grammars/basic/Test16/grammar.json
@@ -66,6 +66,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]
@@ -100,6 +103,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]
@@ -134,6 +140,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]
@@ -168,6 +177,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/basic/Test19/result3.json
+++ b/test/resources/grammars/basic/Test19/result3.json
@@ -1,12 +1,10 @@
 {
-  "kind" : "MetaSymbolNode",
+  "kind" : "StartNode",
   "symbol" : {
     "kind" : "Start",
     "name" : "Start(E)",
     "startSymbol" : "E"
   },
-  "start" : 0,
-  "end" : 9,
   "children" : [
     {
       "kind" : "AmbiguityNode",
@@ -28,7 +26,8 @@
                   },
                   {
                     "kind" : "Terminal",
-                    "name" : "+",
+                    "name" : "'+'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 43
@@ -75,7 +74,8 @@
                           },
                           {
                             "kind" : "Terminal",
-                            "name" : "+",
+                            "name" : "'+'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 43
@@ -115,7 +115,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -142,10 +143,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -159,10 +161,11 @@
                           "end" : 1
                         },
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "+",
+                            "name" : "'+'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 43
@@ -185,7 +188,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -225,7 +229,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -252,10 +257,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -269,10 +275,11 @@
                               "end" : 3
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -291,7 +298,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -318,10 +326,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -356,7 +365,8 @@
                           },
                           {
                             "kind" : "Terminal",
-                            "name" : "*",
+                            "name" : "'*'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 42
@@ -400,7 +410,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -440,7 +451,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -467,10 +479,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -484,10 +497,11 @@
                               "end" : 1
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -506,7 +520,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -533,10 +548,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -554,10 +570,11 @@
                           "end" : 3
                         },
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "*",
+                            "name" : "'*'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 42
@@ -576,7 +593,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -603,10 +621,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -626,10 +645,11 @@
                   ]
                 },
                 {
-                  "kind" : "TerminalNode",
+                  "kind" : "KeywordTerminalNode",
                   "terminal" : {
                     "kind" : "Terminal",
-                    "name" : "+",
+                    "name" : "'+'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 43
@@ -652,7 +672,8 @@
                       },
                       {
                         "kind" : "Terminal",
-                        "name" : "*",
+                        "name" : "'*'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 42
@@ -692,7 +713,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -719,10 +741,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -736,10 +759,11 @@
                       "end" : 7
                     },
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "*",
+                        "name" : "'*'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 42
@@ -758,7 +782,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -785,10 +810,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -823,7 +849,8 @@
                   },
                   {
                     "kind" : "Terminal",
-                    "name" : "+",
+                    "name" : "'+'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 43
@@ -863,7 +890,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "a",
+                        "name" : "'a'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 97
@@ -890,10 +918,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "a",
+                        "name" : "'a'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 97
@@ -907,10 +936,11 @@
                   "end" : 1
                 },
                 {
-                  "kind" : "TerminalNode",
+                  "kind" : "KeywordTerminalNode",
                   "terminal" : {
                     "kind" : "Terminal",
-                    "name" : "+",
+                    "name" : "'+'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 43
@@ -936,7 +966,8 @@
                           },
                           {
                             "kind" : "Terminal",
-                            "name" : "+",
+                            "name" : "'+'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 43
@@ -980,7 +1011,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -1020,7 +1052,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1047,10 +1080,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1064,10 +1098,11 @@
                               "end" : 3
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -1086,7 +1121,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1113,10 +1149,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1134,10 +1171,11 @@
                           "end" : 5
                         },
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "+",
+                            "name" : "'+'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 43
@@ -1160,7 +1198,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -1200,7 +1239,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1227,10 +1267,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1244,10 +1285,11 @@
                               "end" : 7
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -1266,7 +1308,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1293,10 +1336,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1334,7 +1378,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -1381,7 +1426,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -1425,7 +1471,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -1465,7 +1512,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1492,10 +1540,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1509,10 +1558,11 @@
                                           "end" : 3
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -1531,7 +1581,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1558,10 +1609,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1579,10 +1631,11 @@
                                       "end" : 5
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -1601,7 +1654,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -1628,10 +1682,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -1662,7 +1717,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -1702,7 +1758,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -1729,10 +1786,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -1746,10 +1804,11 @@
                                       "end" : 3
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -1772,7 +1831,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -1812,7 +1872,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1839,10 +1900,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1856,10 +1918,11 @@
                                           "end" : 5
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -1878,7 +1941,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1905,10 +1969,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -1932,10 +1997,11 @@
                               ]
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -1954,7 +2020,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -1981,10 +2048,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -2015,7 +2083,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -2055,7 +2124,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -2082,10 +2152,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -2099,10 +2170,11 @@
                               "end" : 3
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -2128,7 +2200,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -2168,7 +2241,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -2195,10 +2269,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -2212,10 +2287,11 @@
                                       "end" : 5
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -2238,7 +2314,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -2278,7 +2355,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2305,10 +2383,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2322,10 +2401,11 @@
                                           "end" : 7
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -2344,7 +2424,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2371,10 +2452,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2409,7 +2491,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -2453,7 +2536,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -2493,7 +2577,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2520,10 +2605,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2537,10 +2623,11 @@
                                           "end" : 5
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -2559,7 +2646,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2586,10 +2674,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -2607,10 +2696,11 @@
                                       "end" : 7
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -2629,7 +2719,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -2656,10 +2747,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -2709,7 +2801,8 @@
                   },
                   {
                     "kind" : "Terminal",
-                    "name" : "*",
+                    "name" : "'*'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 42
@@ -2753,7 +2846,8 @@
                       },
                       {
                         "kind" : "Terminal",
-                        "name" : "+",
+                        "name" : "'+'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 43
@@ -2793,7 +2887,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -2820,10 +2915,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -2837,10 +2933,11 @@
                       "end" : 1
                     },
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "+",
+                        "name" : "'+'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 43
@@ -2859,7 +2956,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -2886,10 +2984,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "a",
+                            "name" : "'a'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 97
@@ -2907,10 +3006,11 @@
                   "end" : 3
                 },
                 {
-                  "kind" : "TerminalNode",
+                  "kind" : "KeywordTerminalNode",
                   "terminal" : {
                     "kind" : "Terminal",
-                    "name" : "*",
+                    "name" : "'*'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 42
@@ -2936,7 +3036,8 @@
                           },
                           {
                             "kind" : "Terminal",
-                            "name" : "+",
+                            "name" : "'+'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 43
@@ -2976,7 +3077,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -3003,10 +3105,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -3020,10 +3123,11 @@
                           "end" : 5
                         },
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "+",
+                            "name" : "'+'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 43
@@ -3046,7 +3150,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -3086,7 +3191,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3113,10 +3219,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3130,10 +3237,11 @@
                               "end" : 7
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "*",
+                                "name" : "'*'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 42
@@ -3152,7 +3260,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3179,10 +3288,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3217,7 +3327,8 @@
                           },
                           {
                             "kind" : "Terminal",
-                            "name" : "*",
+                            "name" : "'*'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 42
@@ -3261,7 +3372,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -3301,7 +3413,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3328,10 +3441,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3345,10 +3459,11 @@
                               "end" : 5
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -3367,7 +3482,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3394,10 +3510,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -3415,10 +3532,11 @@
                           "end" : 7
                         },
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "*",
+                            "name" : "'*'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 42
@@ -3437,7 +3555,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -3464,10 +3583,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "a",
+                                "name" : "'a'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 97
@@ -3504,7 +3624,8 @@
                   },
                   {
                     "kind" : "Terminal",
-                    "name" : "*",
+                    "name" : "'*'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 42
@@ -3554,7 +3675,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -3601,7 +3723,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -3641,7 +3764,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -3668,10 +3792,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -3685,10 +3810,11 @@
                                       "end" : 1
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -3711,7 +3837,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -3751,7 +3878,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -3778,10 +3906,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -3795,10 +3924,11 @@
                                           "end" : 3
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -3817,7 +3947,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -3844,10 +3975,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -3882,7 +4014,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -3926,7 +4059,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -3966,7 +4100,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -3993,10 +4128,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4010,10 +4146,11 @@
                                           "end" : 1
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -4032,7 +4169,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4059,10 +4197,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4080,10 +4219,11 @@
                                       "end" : 3
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -4102,7 +4242,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -4129,10 +4270,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -4152,10 +4294,11 @@
                               ]
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -4174,7 +4317,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -4201,10 +4345,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -4235,7 +4380,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -4275,7 +4421,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -4302,10 +4449,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -4319,10 +4467,11 @@
                               "end" : 1
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -4348,7 +4497,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -4392,7 +4542,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -4432,7 +4583,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4459,10 +4611,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4476,10 +4629,11 @@
                                           "end" : 3
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "*",
+                                            "name" : "'*'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 42
@@ -4498,7 +4652,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4525,10 +4680,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4546,10 +4702,11 @@
                                       "end" : 5
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "+",
+                                        "name" : "'+'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 43
@@ -4568,7 +4725,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -4595,10 +4753,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -4629,7 +4788,8 @@
                                       },
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -4669,7 +4829,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -4696,10 +4857,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "a",
+                                            "name" : "'a'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 97
@@ -4713,10 +4875,11 @@
                                       "end" : 3
                                     },
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "*",
+                                        "name" : "'*'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 42
@@ -4739,7 +4902,8 @@
                                           },
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -4779,7 +4943,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4806,10 +4971,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4823,10 +4989,11 @@
                                           "end" : 5
                                         },
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "+",
+                                            "name" : "'+'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 43
@@ -4845,7 +5012,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4872,10 +5040,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "a",
+                                                "name" : "'a'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 97
@@ -4918,7 +5087,8 @@
                           },
                           {
                             "kind" : "Terminal",
-                            "name" : "*",
+                            "name" : "'*'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 42
@@ -4962,7 +5132,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -5002,7 +5173,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5029,10 +5201,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5046,10 +5219,11 @@
                               "end" : 1
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -5068,7 +5242,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5095,10 +5270,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5116,10 +5292,11 @@
                           "end" : 3
                         },
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "*",
+                            "name" : "'*'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 42
@@ -5142,7 +5319,8 @@
                               },
                               {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -5182,7 +5360,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5209,10 +5388,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5226,10 +5406,11 @@
                               "end" : 5
                             },
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "+",
+                                "name" : "'+'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 43
@@ -5248,7 +5429,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5275,10 +5457,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "a",
+                                    "name" : "'a'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 97
@@ -5302,10 +5485,11 @@
                   ]
                 },
                 {
-                  "kind" : "TerminalNode",
+                  "kind" : "KeywordTerminalNode",
                   "terminal" : {
                     "kind" : "Terminal",
-                    "name" : "*",
+                    "name" : "'*'",
+                    "nodeType" : "Literal",
                     "regex" : {
                       "kind" : "Char",
                       "val" : 42
@@ -5324,7 +5508,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "a",
+                        "name" : "'a'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 97
@@ -5351,10 +5536,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "a",
+                        "name" : "'a'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 97
@@ -5375,5 +5561,7 @@
         }
       ]
     }
-  ]
+  ],
+  "start" : 0,
+  "end" : 9
 }

--- a/test/resources/grammars/basic/Test20/grammar.json
+++ b/test/resources/grammars/basic/Test20/grammar.json
@@ -67,6 +67,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]
@@ -141,6 +144,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/gamma/Test1/grammar.json
+++ b/test/resources/grammars/gamma/Test1/grammar.json
@@ -59,6 +59,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/gamma/Test2/grammar.json
+++ b/test/resources/grammars/gamma/Test2/grammar.json
@@ -54,6 +54,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/gamma/Test3/result3.json
+++ b/test/resources/grammars/gamma/Test3/result3.json
@@ -1,12 +1,10 @@
 {
-  "kind" : "MetaSymbolNode",
+  "kind" : "StartNode",
   "symbol" : {
     "kind" : "Start",
     "name" : "Start(S)",
     "startSymbol" : "S"
   },
-  "start" : 0,
-  "end" : 5,
   "children" : [
     {
       "kind" : "AmbiguityNode",
@@ -180,7 +178,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -207,10 +206,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -233,7 +233,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -260,10 +261,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -290,7 +292,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -317,10 +320,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -383,7 +387,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -410,10 +415,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -472,7 +478,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -499,10 +506,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -525,7 +533,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -552,10 +561,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -628,7 +638,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -655,10 +666,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -681,7 +693,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -708,10 +721,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -734,7 +748,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -761,10 +776,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -793,7 +809,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -820,10 +837,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -922,7 +940,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -949,10 +968,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -975,7 +995,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -1002,10 +1023,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -1068,7 +1090,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -1095,10 +1118,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -1121,7 +1145,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -1148,10 +1173,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -1218,7 +1244,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -1245,10 +1272,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -1313,7 +1341,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -1340,10 +1369,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -1402,7 +1432,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1429,10 +1460,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1455,7 +1487,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1482,10 +1515,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1588,7 +1622,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1615,10 +1650,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1641,7 +1677,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1668,10 +1705,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -1698,7 +1736,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -1725,10 +1764,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -1797,7 +1837,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -1824,10 +1865,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -1850,7 +1892,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -1877,10 +1920,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -1903,7 +1947,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -1930,10 +1975,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -2047,7 +2093,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2074,10 +2121,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2100,7 +2148,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2127,10 +2176,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2157,7 +2207,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2184,10 +2235,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2210,7 +2262,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2237,10 +2290,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2307,7 +2361,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2334,10 +2389,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2396,7 +2452,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2423,10 +2480,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2449,7 +2507,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2476,10 +2535,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2506,7 +2566,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2533,10 +2594,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2603,7 +2665,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2630,10 +2693,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2656,7 +2720,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2683,10 +2748,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -2745,7 +2811,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2772,10 +2839,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2798,7 +2866,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2825,10 +2894,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -2863,7 +2933,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -2890,10 +2961,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -3034,7 +3106,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3061,10 +3134,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3087,7 +3161,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3114,10 +3189,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3144,7 +3220,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -3171,10 +3248,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -3237,7 +3315,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -3264,10 +3343,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -3326,7 +3406,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3353,10 +3434,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3379,7 +3461,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3406,10 +3489,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -3482,7 +3566,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -3509,10 +3594,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -3535,7 +3621,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -3562,10 +3649,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -3588,7 +3676,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -3615,10 +3704,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -3683,7 +3773,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3710,10 +3801,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3736,7 +3828,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3763,10 +3856,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3869,7 +3963,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3896,10 +3991,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3922,7 +4018,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -3949,10 +4046,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -4021,7 +4119,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -4048,10 +4147,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -4110,7 +4210,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4137,10 +4238,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4163,7 +4265,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4190,10 +4293,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4296,7 +4400,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4323,10 +4428,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4349,7 +4455,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4376,10 +4483,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -4406,7 +4514,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -4433,10 +4542,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -4505,7 +4615,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -4532,10 +4643,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -4558,7 +4670,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -4585,10 +4698,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -4611,7 +4725,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -4638,10 +4753,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -4710,7 +4826,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -4737,10 +4854,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -4805,7 +4923,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -4832,10 +4951,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -4900,7 +5020,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -4927,10 +5048,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -4989,7 +5111,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5016,10 +5139,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5042,7 +5166,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5069,10 +5194,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5175,7 +5301,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5202,10 +5329,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5228,7 +5356,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5255,10 +5384,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5285,7 +5415,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -5312,10 +5443,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -5384,7 +5516,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -5411,10 +5544,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -5437,7 +5571,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -5464,10 +5599,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -5490,7 +5626,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -5517,10 +5654,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -5631,7 +5769,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -5658,10 +5797,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -5720,7 +5860,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5747,10 +5888,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5773,7 +5915,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5800,10 +5943,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5906,7 +6050,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5933,10 +6078,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5959,7 +6105,8 @@
                                                 "body" : [
                                                   {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -5986,10 +6133,11 @@
                                               },
                                               "children" : [
                                                 {
-                                                  "kind" : "TerminalNode",
+                                                  "kind" : "KeywordTerminalNode",
                                                   "terminal" : {
                                                     "kind" : "Terminal",
-                                                    "name" : "b",
+                                                    "name" : "'b'",
+                                                    "nodeType" : "Literal",
                                                     "regex" : {
                                                       "kind" : "Char",
                                                       "val" : 98
@@ -6016,7 +6164,8 @@
                                             "body" : [
                                               {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -6043,10 +6192,11 @@
                                           },
                                           "children" : [
                                             {
-                                              "kind" : "TerminalNode",
+                                              "kind" : "KeywordTerminalNode",
                                               "terminal" : {
                                                 "kind" : "Terminal",
-                                                "name" : "b",
+                                                "name" : "'b'",
+                                                "nodeType" : "Literal",
                                                 "regex" : {
                                                   "kind" : "Char",
                                                   "val" : 98
@@ -6115,7 +6265,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -6142,10 +6293,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -6168,7 +6320,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -6195,10 +6348,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -6221,7 +6375,8 @@
                                         "body" : [
                                           {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -6248,10 +6403,11 @@
                                       },
                                       "children" : [
                                         {
-                                          "kind" : "TerminalNode",
+                                          "kind" : "KeywordTerminalNode",
                                           "terminal" : {
                                             "kind" : "Terminal",
-                                            "name" : "b",
+                                            "name" : "'b'",
+                                            "nodeType" : "Literal",
                                             "regex" : {
                                               "kind" : "Char",
                                               "val" : 98
@@ -6280,7 +6436,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -6307,10 +6464,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -6409,7 +6567,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6436,10 +6595,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6462,7 +6622,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6489,10 +6650,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6555,7 +6717,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6582,10 +6745,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6608,7 +6772,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6635,10 +6800,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6750,7 +6916,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6777,10 +6944,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6803,7 +6971,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6830,10 +6999,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -6860,7 +7030,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -6887,10 +7058,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -6913,7 +7085,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -6940,10 +7113,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7010,7 +7184,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7037,10 +7212,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7099,7 +7275,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7126,10 +7303,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7152,7 +7330,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7179,10 +7358,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7209,7 +7389,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7236,10 +7417,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7306,7 +7488,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7333,10 +7516,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7359,7 +7543,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7386,10 +7571,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -7448,7 +7634,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7475,10 +7662,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7501,7 +7689,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7528,10 +7717,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -7651,7 +7841,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7678,10 +7869,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7704,7 +7896,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7731,10 +7924,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7797,7 +7991,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7824,10 +8019,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7850,7 +8046,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7877,10 +8074,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -7907,7 +8105,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -7934,10 +8133,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -7996,7 +8196,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8023,10 +8224,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8049,7 +8251,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8076,10 +8279,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8106,7 +8310,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -8133,10 +8338,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -8195,7 +8401,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8222,10 +8429,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8248,7 +8456,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8275,10 +8484,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8385,7 +8595,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8412,10 +8623,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8438,7 +8650,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8465,10 +8678,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8531,7 +8745,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8558,10 +8773,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8584,7 +8800,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8611,10 +8828,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8641,7 +8859,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -8668,10 +8887,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -8694,7 +8914,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -8721,10 +8942,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -8783,7 +9005,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8810,10 +9033,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8836,7 +9060,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8863,10 +9088,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8929,7 +9155,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8956,10 +9183,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -8982,7 +9210,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -9009,10 +9238,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -9161,7 +9391,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9188,10 +9419,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9214,7 +9446,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9241,10 +9474,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9271,7 +9505,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -9298,10 +9533,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -9364,7 +9600,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -9391,10 +9628,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -9453,7 +9691,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9480,10 +9719,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9506,7 +9746,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9533,10 +9774,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -9609,7 +9851,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -9636,10 +9879,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -9662,7 +9906,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -9689,10 +9934,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -9715,7 +9961,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -9742,10 +9989,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -9774,7 +10022,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -9801,10 +10050,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -9827,7 +10077,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -9854,10 +10105,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -9916,7 +10168,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -9943,10 +10196,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -9969,7 +10223,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -9996,10 +10251,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -10026,7 +10282,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -10053,10 +10310,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -10115,7 +10373,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -10142,10 +10401,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -10168,7 +10428,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -10195,10 +10456,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -10347,7 +10609,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10374,10 +10637,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10400,7 +10664,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10427,10 +10692,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10457,7 +10723,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -10484,10 +10751,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -10550,7 +10818,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -10577,10 +10846,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -10639,7 +10909,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10666,10 +10937,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10692,7 +10964,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10719,10 +10992,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -10795,7 +11069,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -10822,10 +11097,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -10848,7 +11124,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -10875,10 +11152,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -10901,7 +11179,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -10928,10 +11207,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -10960,7 +11240,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -10987,10 +11268,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11013,7 +11295,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11040,10 +11323,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11066,7 +11350,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11093,10 +11378,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11155,7 +11441,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11182,10 +11469,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11208,7 +11496,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11235,10 +11524,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11301,7 +11591,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11328,10 +11619,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11354,7 +11646,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11381,10 +11674,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -11455,7 +11749,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11482,10 +11777,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -11550,7 +11846,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -11577,10 +11874,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -11639,7 +11937,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11666,10 +11965,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11692,7 +11992,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11719,10 +12020,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11825,7 +12127,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11852,10 +12155,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11878,7 +12182,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11905,10 +12210,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -11935,7 +12241,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -11962,10 +12269,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -12034,7 +12342,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -12061,10 +12370,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -12087,7 +12397,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -12114,10 +12425,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -12140,7 +12452,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -12167,10 +12480,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -12199,7 +12513,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -12226,10 +12541,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -12288,7 +12604,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12315,10 +12632,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12341,7 +12659,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12368,10 +12687,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12398,7 +12718,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -12425,10 +12746,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -12487,7 +12809,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12514,10 +12837,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12540,7 +12864,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12567,10 +12892,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -12641,7 +12967,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -12668,10 +12995,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -12736,7 +13064,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -12763,10 +13092,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -12825,7 +13155,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -12852,10 +13183,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -12878,7 +13210,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -12905,10 +13238,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -13011,7 +13345,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -13038,10 +13373,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -13064,7 +13400,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -13091,10 +13428,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -13121,7 +13459,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -13148,10 +13487,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -13220,7 +13560,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -13247,10 +13588,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -13273,7 +13615,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -13300,10 +13643,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -13326,7 +13670,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -13353,10 +13698,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -13385,7 +13731,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13412,10 +13759,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13438,7 +13786,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13465,10 +13814,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13527,7 +13877,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13554,10 +13905,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13580,7 +13932,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13607,10 +13960,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13673,7 +14027,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13700,10 +14055,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13726,7 +14082,8 @@
                         "body" : [
                           {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13753,10 +14110,11 @@
                       },
                       "children" : [
                         {
-                          "kind" : "TerminalNode",
+                          "kind" : "KeywordTerminalNode",
                           "terminal" : {
                             "kind" : "Terminal",
-                            "name" : "b",
+                            "name" : "'b'",
+                            "nodeType" : "Literal",
                             "regex" : {
                               "kind" : "Char",
                               "val" : 98
@@ -13827,7 +14185,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13854,10 +14213,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13880,7 +14240,8 @@
                     "body" : [
                       {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13907,10 +14268,11 @@
                   },
                   "children" : [
                     {
-                      "kind" : "TerminalNode",
+                      "kind" : "KeywordTerminalNode",
                       "terminal" : {
                         "kind" : "Terminal",
-                        "name" : "b",
+                        "name" : "'b'",
+                        "nodeType" : "Literal",
                         "regex" : {
                           "kind" : "Char",
                           "val" : 98
@@ -13975,7 +14337,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -14002,10 +14365,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -14064,7 +14428,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14091,10 +14456,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14117,7 +14483,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14144,10 +14511,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14250,7 +14618,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14277,10 +14646,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14303,7 +14673,8 @@
                                     "body" : [
                                       {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14330,10 +14701,11 @@
                                   },
                                   "children" : [
                                     {
-                                      "kind" : "TerminalNode",
+                                      "kind" : "KeywordTerminalNode",
                                       "terminal" : {
                                         "kind" : "Terminal",
-                                        "name" : "b",
+                                        "name" : "'b'",
+                                        "nodeType" : "Literal",
                                         "regex" : {
                                           "kind" : "Char",
                                           "val" : 98
@@ -14360,7 +14732,8 @@
                                 "body" : [
                                   {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -14387,10 +14760,11 @@
                               },
                               "children" : [
                                 {
-                                  "kind" : "TerminalNode",
+                                  "kind" : "KeywordTerminalNode",
                                   "terminal" : {
                                     "kind" : "Terminal",
-                                    "name" : "b",
+                                    "name" : "'b'",
+                                    "nodeType" : "Literal",
                                     "regex" : {
                                       "kind" : "Char",
                                       "val" : 98
@@ -14459,7 +14833,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -14486,10 +14861,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -14512,7 +14888,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -14539,10 +14916,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -14565,7 +14943,8 @@
                             "body" : [
                               {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -14592,10 +14971,11 @@
                           },
                           "children" : [
                             {
-                              "kind" : "TerminalNode",
+                              "kind" : "KeywordTerminalNode",
                               "terminal" : {
                                 "kind" : "Terminal",
-                                "name" : "b",
+                                "name" : "'b'",
+                                "nodeType" : "Literal",
                                 "regex" : {
                                   "kind" : "Char",
                                   "val" : 98
@@ -14622,5 +15002,7 @@
         }
       ]
     }
-  ]
+  ],
+  "start" : 0,
+  "end" : 5
 }

--- a/test/resources/grammars/gamma/Test4/grammar.json
+++ b/test/resources/grammars/gamma/Test4/grammar.json
@@ -67,6 +67,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/layout/Test2/grammar.json
+++ b/test/resources/grammars/layout/Test2/grammar.json
@@ -75,6 +75,9 @@
         {
           "alternatives" : [
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/recursion/Test1/grammar.json
+++ b/test/resources/grammars/recursion/Test1/grammar.json
@@ -89,6 +89,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/recursion/Test2/grammar.json
+++ b/test/resources/grammars/recursion/Test2/grammar.json
@@ -112,6 +112,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]
@@ -146,6 +149,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]

--- a/test/resources/grammars/recursion/Test4/grammar.json
+++ b/test/resources/grammars/recursion/Test4/grammar.json
@@ -85,6 +85,9 @@
               "associativity" : "UNDEFINED"
             },
             {
+              "seqs" : [
+                { }
+              ],
               "associativity" : "UNDEFINED"
             }
           ]


### PR DESCRIPTION
This PR provides support for converting Iguana to Rascal parse trees. The main changes in this PR are done in the `ParseTreeBuilder` class to flatten the EBNF star nodes implicitly, without creating explicit `Plus` nodes in between. 