### PR TITLE
Panic mode error recovery

### DIFF
--- a/src/org/iguana/datadependent/attrs/AbstractAttrs.java
+++ b/src/org/iguana/datadependent/attrs/AbstractAttrs.java
@@ -32,7 +32,7 @@ import io.usethesource.capsule.Set;
 
 public abstract class AbstractAttrs implements Attr {
 	
-	private transient Set.Immutable<String> env;
+	private Set.Immutable<String> env;
 
 	@Override
 	public Set.Immutable<String> getEnv() {

--- a/src/org/iguana/datadependent/traversal/FreeVariableVisitor.java
+++ b/src/org/iguana/datadependent/traversal/FreeVariableVisitor.java
@@ -39,6 +39,7 @@ import org.iguana.grammar.condition.DataDependentCondition;
 import org.iguana.grammar.condition.PositionalCondition;
 import org.iguana.grammar.condition.RegularExpressionCondition;
 import org.iguana.grammar.runtime.RuntimeRule;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.IfThenElse;
 import org.iguana.grammar.symbol.*;
 import org.iguana.traversal.IConditionVisitor;
@@ -522,7 +523,12 @@ public class FreeVariableVisitor implements IAbstractASTVisitor<Void>, ISymbolVi
 		
 		return null;
 	}
-	
+
+	@Override
+	public Void visit(Error error) {
+		return null;
+	}
+
 	@Override
 	public Void visit(Conditional symbol) {
 		

--- a/src/org/iguana/datadependent/traversal/ValUses.java
+++ b/src/org/iguana/datadependent/traversal/ValUses.java
@@ -13,6 +13,7 @@ import org.iguana.grammar.condition.PositionalCondition;
 import org.iguana.grammar.condition.RegularExpressionCondition;
 import org.iguana.grammar.exception.UnexpectedSymbolException;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.IfThenElse;
 import org.iguana.traversal.IConditionVisitor;
 import org.iguana.traversal.ISymbolVisitor;
@@ -57,6 +58,11 @@ public class ValUses implements IAbstractASTVisitor<Void>, ISymbolVisitor<Void>,
 		for (Statement stat : symbol.getStatements())
 			stat.accept(this);
 		
+		return null;
+	}
+
+	@Override
+	public Void visit(Error error) {
 		return null;
 	}
 

--- a/src/org/iguana/grammar/Grammar.java
+++ b/src/org/iguana/grammar/Grammar.java
@@ -8,6 +8,7 @@ import org.iguana.grammar.runtime.*;
 import org.iguana.grammar.slot.NonterminalNodeType;
 import org.iguana.grammar.slot.TerminalNodeType;
 import org.iguana.grammar.symbol.Alt;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.Opt;
 import org.iguana.grammar.symbol.Plus;
 import org.iguana.grammar.symbol.Star;
@@ -542,6 +543,11 @@ public class Grammar {
         }
 
         @Override
+        public Void visit(Error error) {
+            return null;
+        }
+
+        @Override
         public Void visit(Conditional conditional) {
             return visitChildren(conditional);
         }
@@ -746,6 +752,11 @@ public class Grammar {
         @Override
         public Boolean visit(Code symbol) {
             return symbol.getSymbol().accept(this);
+        }
+
+        @Override
+        public Boolean visit(Error error) {
+            return false;
         }
 
         @Override

--- a/src/org/iguana/grammar/GrammarGraphBuilder.java
+++ b/src/org/iguana/grammar/GrammarGraphBuilder.java
@@ -327,7 +327,7 @@ public class GrammarGraphBuilder {
          */
         private void visitSymbol(Symbol symbol) {
 
-            if (symbol instanceof Nonterminal || symbol instanceof Terminal || symbol instanceof Return) { // TODO: I think this can be unified
+            if (symbol instanceof Nonterminal || symbol instanceof Terminal || symbol instanceof Error || symbol instanceof Return) { // TODO: I think this can be unified
                 symbol.accept(this);
                 return;
             }

--- a/src/org/iguana/grammar/GrammarGraphBuilder.java
+++ b/src/org/iguana/grammar/GrammarGraphBuilder.java
@@ -42,6 +42,7 @@ import org.iguana.grammar.slot.EpsilonTransition.Type;
 import org.iguana.grammar.slot.lookahead.FollowTest;
 import org.iguana.grammar.slot.lookahead.RangeTreeFollowTest;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.transformation.VarToInt;
 import org.iguana.regex.CharRange;
 import org.iguana.regex.matcher.DFAMatcherFactory;
@@ -266,6 +267,21 @@ public class GrammarGraphBuilder {
             setTransition(transition);
             currentSlot = done;
 
+            return null;
+        }
+
+        @Override
+        public Void visit(Error error) {
+            BodyGrammarSlot slot;
+
+            if (i == rule.size() - 1 && j == -1)
+                slot = getEndSlot(rule, i + 1, rule.getPosition(i + 1), head, null, null, null);
+            else
+                slot = getBodyGrammarSlot(rule, i + 1, rule.getPosition(i + 1), null, null, null);
+
+            ErrorTransition transition = new ErrorTransition(currentSlot, slot);
+            setTransition(transition);
+            currentSlot = slot;
             return null;
         }
 

--- a/src/org/iguana/grammar/condition/ConditionsFactory.java
+++ b/src/org/iguana/grammar/condition/ConditionsFactory.java
@@ -81,7 +81,7 @@ public class ConditionsFactory {
 					for (int j = 0; j < actions.size(); j++) {
 						SlotAction slotAction = actions.get(j);
 					    if (slotAction.execute(input, slot, gssNode, lefExtent, rightExtent, ctx)) {
-                            runtime.recordParseError(rightExtent, slot, gssNode, slotAction.toString());
+                            runtime.recordParseError(rightExtent, input, slot, gssNode, slotAction.toString());
 			                return true;
 			            }
 			        }
@@ -103,7 +103,7 @@ public class ConditionsFactory {
                 for (int j = 0; j < actions.size(); j++) {
                     SlotAction slotAction = actions.get(j);
                     if (slotAction.execute(input, slot, gssNode, leftExtent, rightExtent, ctx)) {
-                        runtime.recordParseError(rightExtent, slot, gssNode, slotAction.toString());
+                        runtime.recordParseError(rightExtent, input, slot, gssNode, slotAction.toString());
                         return true;
                     }
                 }

--- a/src/org/iguana/grammar/operations/FirstFollowSets.java
+++ b/src/org/iguana/grammar/operations/FirstFollowSets.java
@@ -27,6 +27,7 @@
 
 package org.iguana.grammar.operations;
 
+import org.iguana.grammar.symbol.Error;
 import org.iguana.regex.CharRange;
 import org.iguana.regex.EOF;
 import org.iguana.regex.Epsilon;
@@ -372,6 +373,11 @@ public class FirstFollowSets {
 		public Set<CharRange> visit(Code symbol) { return symbol.getSymbol().accept(this); }
 
 		@Override
+		public Set<CharRange> visit(Error error) {
+			return Collections.emptySet();
+		}
+
+		@Override
 		public Set<CharRange> visit(Conditional symbol) { return symbol.getSymbol().accept(this); }
 
 		@Override
@@ -383,13 +389,18 @@ public class FirstFollowSets {
         }
 
         @Override
-		public Set<CharRange> visit(Return symbol) { return new HashSet<>(); }
+		public Set<CharRange> visit(Return symbol) { return Collections.emptySet(); }
 
     }
 
     private static class NonterminalVisitor extends AbstractGrammarGraphSymbolVisitor<Nonterminal> {
 		@Override
 		public Nonterminal visit(Code symbol) { return symbol.getSymbol().accept(this); }
+
+		@Override
+		public Nonterminal visit(Error error) {
+			return null;
+		}
 
 		@Override
 		public Nonterminal visit(Conditional symbol) { return symbol.getSymbol().accept(this); }
@@ -417,6 +428,11 @@ public class FirstFollowSets {
     	
 		@Override
 		public Boolean visit(Code symbol) { return symbol.getSymbol().accept(this); }
+
+		@Override
+		public Boolean visit(Error error) {
+			return true;
+		}
 
 		@Override
 		public Boolean visit(Conditional symbol) { return symbol.getSymbol().accept(this); }

--- a/src/org/iguana/grammar/operations/ReachabilityGraph.java
+++ b/src/org/iguana/grammar/operations/ReachabilityGraph.java
@@ -29,6 +29,7 @@ package org.iguana.grammar.operations;
 
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.runtime.RuntimeRule;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.*;
 import org.iguana.traversal.ISymbolVisitor;
 
@@ -147,6 +148,11 @@ public class ReachabilityGraph {
 		@Override
 		public Boolean visit(Code symbol) {
 			return symbol.getSymbol().accept(this);
+		}
+
+		@Override
+		public Boolean visit(Error error) {
+			return false;
 		}
 
 		@Override

--- a/src/org/iguana/grammar/runtime/RuntimeRule.java
+++ b/src/org/iguana/grammar/runtime/RuntimeRule.java
@@ -460,6 +460,8 @@ public class RuntimeRule {
 
         public RuntimeRule build() {
             if (body == null) body = Collections.emptyList();
+            if (body.stream().anyMatch(Objects::isNull))
+                throw new IllegalArgumentException("symbols cannot be null: " + body);
             return new RuntimeRule(this);
         }
     }

--- a/src/org/iguana/grammar/slot/EndGrammarSlot.java
+++ b/src/org/iguana/grammar/slot/EndGrammarSlot.java
@@ -79,7 +79,7 @@ public class EndGrammarSlot extends BodyGrammarSlot {
 		if (followTest.test(nextChar)) {
 			u.pop(input, this, result, value, runtime);
 		} else {
-			runtime.recordParseError(rightExtent, this, u, "Expected " + followTest + " but was " + (char) nextChar);
+			runtime.recordParseError(rightExtent, input, this, u, "Expected " + followTest + " but was " + (char) nextChar);
 		}
 	}
 

--- a/src/org/iguana/grammar/slot/EpsilonGrammarSlot.java
+++ b/src/org/iguana/grammar/slot/EpsilonGrammarSlot.java
@@ -59,7 +59,7 @@ public class EpsilonGrammarSlot extends EndGrammarSlot {
 		if (followTest.test(nextChar)) {
 			u.pop(input, this, epsilonSlot.getResult(input, i, this, u, runtime), value, runtime);
 		} else {
-			runtime.recordParseError(i, this, u, "Expected " + followTest + " but was " + (char) nextChar);
+			runtime.recordParseError(i, input, this, u, "Expected " + followTest + " but was " + (char) nextChar);
 		}
 	}
 

--- a/src/org/iguana/grammar/slot/ErrorTransition.java
+++ b/src/org/iguana/grammar/slot/ErrorTransition.java
@@ -1,0 +1,24 @@
+package org.iguana.grammar.slot;
+
+import org.iguana.datadependent.env.Environment;
+import org.iguana.gss.GSSNode;
+import org.iguana.parser.IguanaRuntime;
+import org.iguana.result.Result;
+import org.iguana.utils.input.Input;
+
+public class ErrorTransition extends AbstractTransition {
+
+    public ErrorTransition(BodyGrammarSlot origin, BodyGrammarSlot dest) {
+        super(origin, dest);
+    }
+
+    @Override
+    public String getLabel() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Result> void execute(Input input, GSSNode<T> u, T result, Environment env, IguanaRuntime<T> runtime) {
+        dest.execute(input, u, result, runtime.getEnvironment(), runtime);
+    }
+}

--- a/src/org/iguana/grammar/slot/ErrorTransition.java
+++ b/src/org/iguana/grammar/slot/ErrorTransition.java
@@ -18,14 +18,13 @@ public class ErrorTransition extends AbstractTransition {
     }
 
     public <T extends Result> void handleError(Input input, GSSNode<T> u, T result, Environment env, IguanaRuntime<T> runtime) {
-        System.out.println(">>>>> Motherfucker we're here!!!");
         int rightExtent = result.isDummy() ? u.getInputIndex() : result.getRightExtent();
         int i = rightExtent;
         while (i < input.length() && !dest.testFollow(input.charAt(i))) {
             i++;
         }
         if (i == input.length()) {
-            runtime.recordParseError(result.getRightExtent(), this.origin, u, "Could not recover from the error");
+            runtime.recordParseError(rightExtent, this.origin, u, "Could not recover from the error");
         } else {
             T cr = runtime.getResultOps().error(this.dest, rightExtent, i);
             T n = dest.isFirst() ? cr : runtime.getResultOps().merge(null, result, cr, dest);

--- a/src/org/iguana/grammar/slot/ErrorTransition.java
+++ b/src/org/iguana/grammar/slot/ErrorTransition.java
@@ -24,7 +24,7 @@ public class ErrorTransition extends AbstractTransition {
             i++;
         }
         if (i == input.length()) {
-            runtime.recordParseError(rightExtent, this.origin, u, "Could not recover from the error");
+            runtime.recordParseError(rightExtent, input, this.origin, u, "Could not recover from the error");
         } else {
             T cr = runtime.getResultOps().error(this.dest, rightExtent, i);
             T n = dest.isFirst() ? cr : runtime.getResultOps().merge(null, result, cr, dest);

--- a/src/org/iguana/grammar/slot/ErrorTransition.java
+++ b/src/org/iguana/grammar/slot/ErrorTransition.java
@@ -17,8 +17,24 @@ public class ErrorTransition extends AbstractTransition {
         throw new UnsupportedOperationException();
     }
 
+    public <T extends Result> void handleError(Input input, GSSNode<T> u, T result, Environment env, IguanaRuntime<T> runtime) {
+        System.out.println(">>>>> Motherfucker we're here!!!");
+        int rightExtent = result.isDummy() ? u.getInputIndex() : result.getRightExtent();
+        int i = rightExtent;
+        while (i < input.length() && !dest.testFollow(input.charAt(i))) {
+            i++;
+        }
+        if (i == input.length()) {
+            runtime.recordParseError(result.getRightExtent(), this.origin, u, "Could not recover from the error");
+        } else {
+            T cr = runtime.getResultOps().error(this.dest, rightExtent, i);
+            T n = dest.isFirst() ? cr : runtime.getResultOps().merge(null, result, cr, dest);
+            dest.execute(input, u, n, env, runtime);
+        }
+    }
+
     @Override
     public <T extends Result> void execute(Input input, GSSNode<T> u, T result, Environment env, IguanaRuntime<T> runtime) {
-        dest.execute(input, u, result, runtime.getEnvironment(), runtime);
+        dest.execute(input, u, result, env, runtime);
     }
 }

--- a/src/org/iguana/grammar/slot/ErrorTransition.java
+++ b/src/org/iguana/grammar/slot/ErrorTransition.java
@@ -23,12 +23,12 @@ public class ErrorTransition extends AbstractTransition {
         while (i < input.length() && !dest.testFollow(input.charAt(i))) {
             i++;
         }
-        if (i == input.length()) {
-            runtime.recordParseError(rightExtent, input, this.origin, u, "Could not recover from the error");
-        } else {
+        if (i < input.length()) {
             T cr = runtime.getResultOps().error(this.dest, rightExtent, i);
             T n = dest.isFirst() ? cr : runtime.getResultOps().merge(null, result, cr, dest);
             dest.execute(input, u, n, env, runtime);
+        } else {
+            System.out.println("Warning: could not recover from the parse error: " + origin);
         }
     }
 

--- a/src/org/iguana/grammar/slot/TerminalTransition.java
+++ b/src/org/iguana/grammar/slot/TerminalTransition.java
@@ -76,7 +76,7 @@ public class TerminalTransition extends AbstractTransition {
 		T cr = terminalSlot.getResult(input, i, origin, u, runtime);
 		
 		if (cr == null) {
-			runtime.recordParseError(i, origin, u, "Match failed");
+			runtime.recordParseError(i, input, origin, u, "Match failed");
 			return;
 		}
 

--- a/src/org/iguana/grammar/symbol/Error.java
+++ b/src/org/iguana/grammar/symbol/Error.java
@@ -1,0 +1,71 @@
+package org.iguana.grammar.symbol;
+
+import io.usethesource.capsule.Set;
+import org.iguana.grammar.condition.Condition;
+import org.iguana.traversal.ISymbolVisitor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class Error implements Symbol {
+    @Override
+    public Set.Immutable<String> getEnv() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setEnv(Set.Immutable<String> env) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setEmpty() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        return "empty";
+    }
+
+    @Override
+    public List<Condition> getPreConditions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Condition> getPostConditions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getLabel() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SymbolBuilder<? extends Symbol> copy() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString(int j) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T accept(ISymbolVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        return "error";
+    }
+}

--- a/src/org/iguana/grammar/symbol/Error.java
+++ b/src/org/iguana/grammar/symbol/Error.java
@@ -11,17 +11,15 @@ import java.util.Map;
 public class Error implements Symbol {
     @Override
     public Set.Immutable<String> getEnv() {
-        throw new UnsupportedOperationException();
+        return Set.Immutable.of();
     }
 
     @Override
     public void setEnv(Set.Immutable<String> env) {
-        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setEmpty() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -41,7 +39,7 @@ public class Error implements Symbol {
 
     @Override
     public String getLabel() {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override

--- a/src/org/iguana/grammar/symbol/Error.java
+++ b/src/org/iguana/grammar/symbol/Error.java
@@ -1,6 +1,6 @@
 package org.iguana.grammar.symbol;
 
-import io.usethesource.capsule.Set;
+import org.iguana.datadependent.attrs.AbstractAttrs;
 import org.iguana.grammar.condition.Condition;
 import org.iguana.traversal.ISymbolVisitor;
 
@@ -8,23 +8,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class Error implements Symbol {
-    @Override
-    public Set.Immutable<String> getEnv() {
-        return Set.Immutable.of();
+public class Error extends AbstractAttrs implements Symbol {
+
+    private static final Error instance = new Error();
+
+    public static Error getInstance() {
+        return instance;
     }
 
-    @Override
-    public void setEnv(Set.Immutable<String> env) {
-    }
-
-    @Override
-    public void setEmpty() {
-    }
+    private Error() { }
 
     @Override
     public String getName() {
-        return "empty";
+        return "Error";
     }
 
     @Override
@@ -64,6 +60,16 @@ public class Error implements Symbol {
 
     @Override
     public String toString() {
-        return "error";
+        return "Error";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == instance;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(instance);
     }
 }

--- a/src/org/iguana/grammar/transformation/DesugarAlignAndOffside.java
+++ b/src/org/iguana/grammar/transformation/DesugarAlignAndOffside.java
@@ -33,6 +33,7 @@ import org.iguana.grammar.condition.Condition;
 import org.iguana.grammar.operations.ReachabilityGraph;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.traversal.ISymbolVisitor;
 
 import java.util.*;
@@ -280,6 +281,11 @@ public class DesugarAlignAndOffside implements GrammarTransformation {
 				return symbol;
 			
 			return new Code.Builder(sym, symbol.getStatements()).setLabel(symbol.getLabel()).addConditions(symbol).build();
+		}
+
+		@Override
+		public Symbol visit(Error error) {
+			return error;
 		}
 
 		@Override
@@ -610,6 +616,11 @@ public class DesugarAlignAndOffside implements GrammarTransformation {
 		@Override
 		public Void visit(Code symbol) {
 			return symbol.getSymbol().accept(this);
+		}
+
+		@Override
+		public Void visit(Error error) {
+			return null;
 		}
 
 		@Override

--- a/src/org/iguana/grammar/transformation/DesugarPrecedenceAndAssociativity.java
+++ b/src/org/iguana/grammar/transformation/DesugarPrecedenceAndAssociativity.java
@@ -37,6 +37,7 @@ import org.iguana.grammar.runtime.PrecedenceLevel;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.traversal.ISymbolVisitor;
 
 import java.util.Map;
@@ -2382,6 +2383,11 @@ public class DesugarPrecedenceAndAssociativity implements GrammarTransformation 
 				return symbol;
 			
 			return new Code.Builder(sym, symbol.getStatements()).setLabel(symbol.getLabel()).addConditions(symbol).build();
+		}
+
+		@Override
+		public Symbol visit(Error error) {
+			return error;
 		}
 
 		@Override

--- a/src/org/iguana/grammar/transformation/DesugarState.java
+++ b/src/org/iguana/grammar/transformation/DesugarState.java
@@ -35,6 +35,7 @@ import org.iguana.grammar.exception.UnexpectedSymbolException;
 import org.iguana.grammar.operations.ReachabilityGraph;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.Nonterminal.Builder;
 import org.iguana.traversal.ISymbolVisitor;
 
@@ -250,6 +251,11 @@ public class DesugarState implements GrammarTransformation {
 				return symbol;
 			
 			return new Code.Builder(sym, symbol.getStatements()).setLabel(symbol.getLabel()).addConditions(symbol).build();
+		}
+
+		@Override
+		public Symbol visit(Error error) {
+			return error;
 		}
 
 		@Override

--- a/src/org/iguana/grammar/transformation/EBNFToBNF.java
+++ b/src/org/iguana/grammar/transformation/EBNFToBNF.java
@@ -37,6 +37,7 @@ import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.slot.NonterminalNodeType;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.Nonterminal.Builder;
 import org.iguana.traversal.ISymbolVisitor;
 
@@ -529,6 +530,11 @@ public class EBNFToBNF implements GrammarTransformation {
 				return symbol;
 			
 			return new Code.Builder(sym, symbol.getStatements()).setLabel(symbol.getLabel()).addConditions(symbol).build();
+		}
+
+		@Override
+		public Symbol visit(Error error) {
+			return error;
 		}
 
 		@Override

--- a/src/org/iguana/grammar/transformation/FindLabelsUsedInExcepts.java
+++ b/src/org/iguana/grammar/transformation/FindLabelsUsedInExcepts.java
@@ -3,6 +3,7 @@ package org.iguana.grammar.transformation;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.traversal.ISymbolVisitor;
 
 import java.util.HashMap;
@@ -46,6 +47,11 @@ public class FindLabelsUsedInExcepts implements ISymbolVisitor<Void> {
 	@Override
 	public Void visit(Code symbol) {
 		symbol.getSymbol().accept(this);
+		return null;
+	}
+
+	@Override
+	public Void visit(Error error) {
 		return null;
 	}
 

--- a/src/org/iguana/grammar/transformation/VarToInt.java
+++ b/src/org/iguana/grammar/transformation/VarToInt.java
@@ -18,6 +18,7 @@ import org.iguana.grammar.condition.RegularExpressionCondition;
 import org.iguana.grammar.exception.UndeclaredVariableException;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.IfThenElse;
 import org.iguana.traversal.IConditionVisitor;
 import org.iguana.traversal.ISymbolVisitor;
@@ -130,6 +131,11 @@ public class VarToInt implements GrammarTransformation, IAbstractASTVisitor<Abst
             statements[i++] = (Statement) statement.accept(this);
 
         return Code.code(sym, statements);
+    }
+
+    @Override
+    public Symbol visit(Error error) {
+        return error;
     }
 
     @Override

--- a/src/org/iguana/gss/CyclicDummyGSSEdges.java
+++ b/src/org/iguana/gss/CyclicDummyGSSEdges.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * GSSEdge that has the dummy node as its result, but in contract to DummyGSSEdge, represents the special case of a
+ * GSSEdge that has the dummy node as its result, but in contrast to DummyGSSEdge, represents the special case of a
  * direct cycle due to left recursion.
  */
 public class CyclicDummyGSSEdges<T extends Result> implements GSSEdge<T> {
@@ -31,7 +31,7 @@ public class CyclicDummyGSSEdges<T extends Result> implements GSSEdge<T> {
 
     @Override
     public BodyGrammarSlot getReturnSlot() {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override

--- a/src/org/iguana/gss/DefaultGSSNode.java
+++ b/src/org/iguana/gss/DefaultGSSNode.java
@@ -250,7 +250,16 @@ public class DefaultGSSNode<T extends Result> implements GSSNode<T> {
 	}
 
 	public Iterable<GSSEdge<T>> getGSSEdges() {
-		return restGSSEdges;
+		int size = countGSSEdges();
+		if (size == 0) return Collections.emptyList();
+		List<GSSEdge<T>> gssEdges = new ArrayList<>(size);
+		if (firstGSSEdge != null) {
+			gssEdges.add(firstGSSEdge);
+		}
+		if (restGSSEdges != null) {
+			gssEdges.addAll(restGSSEdges);
+		}
+		return gssEdges;
 	}
 
 	public boolean equals(Object obj) {
@@ -266,7 +275,7 @@ public class DefaultGSSNode<T extends Result> implements GSSNode<T> {
 	}
 
 	public int hashCode() {
-		return Objects.hash(getGrammarSlot().hashCode(), getInputIndex(), getData());
+		return Objects.hash(getGrammarSlot().hashCode(), getInputIndex(), Arrays.hashCode(getData()));
 	}
 
 	public Iterable<T> getPoppedElements() {

--- a/src/org/iguana/iggy/IggyParseTreeToGrammarVisitor.java
+++ b/src/org/iguana/iggy/IggyParseTreeToGrammarVisitor.java
@@ -9,6 +9,7 @@ import org.iguana.grammar.condition.PositionalCondition;
 import org.iguana.grammar.condition.RegularExpressionCondition;
 import org.iguana.grammar.slot.NonterminalNodeType;
 import org.iguana.grammar.slot.TerminalNodeType;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.*;
 import org.iguana.iggy.gen.IggyParseTree;
 import org.iguana.iggy.gen.IggyParseTree.RegexRule;
@@ -427,6 +428,11 @@ public class IggyParseTreeToGrammarVisitor implements IggyParseTreeVisitor<Objec
         Symbol symbol = (Symbol) node.sym().accept(this);
         List<Symbol> seps = visit(node.sep());
         return new Plus.Builder(symbol).addSeparators(seps).build();
+    }
+
+    @Override
+    public Object visitErrorSymbol(IggyParseTree.ErrorSymbol node) {
+        return new Error();
     }
 
     @Override

--- a/src/org/iguana/iggy/IggyParseTreeToGrammarVisitor.java
+++ b/src/org/iguana/iggy/IggyParseTreeToGrammarVisitor.java
@@ -432,7 +432,7 @@ public class IggyParseTreeToGrammarVisitor implements IggyParseTreeVisitor<Objec
 
     @Override
     public Object visitErrorSymbol(IggyParseTree.ErrorSymbol node) {
-        return new Error();
+        return Error.getInstance();
     }
 
     @Override

--- a/src/org/iguana/iggy/gen/IggyParseTree.java
+++ b/src/org/iguana/iggy/gen/IggyParseTree.java
@@ -920,6 +920,21 @@ public class IggyParseTree {
         }
     }
 
+    // Symbol = 'error'
+    public static class ErrorSymbol extends Symbol {
+        public ErrorSymbol(RuntimeRule rule, List<ParseTreeNode> children, int start, int end) {
+            super(rule, children, start, end);
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<T> visitor) {
+            if (visitor instanceof IggyParseTreeVisitor) {
+                return ((IggyParseTreeVisitor<T>) visitor).visitErrorSymbol(this);
+            }
+            return visitor.visitNonterminalNode(this);
+        }
+    }
+
     // Arguments = '(' {Expression ','}* ')'
     public static class Arguments extends NonterminalNode {
         public Arguments(RuntimeRule rule, List<ParseTreeNode> children, int start, int end) {

--- a/src/org/iguana/iggy/gen/IggyParseTreeBuilder.java
+++ b/src/org/iguana/iggy/gen/IggyParseTreeBuilder.java
@@ -120,6 +120,8 @@ public class IggyParseTreeBuilder extends DefaultParseTreeBuilder {
                         return new IggyParseTree.StarSepSymbol(rule, children, leftExtent, rightExtent);
                     case "PlusSep":
                         return new IggyParseTree.PlusSepSymbol(rule, children, leftExtent, rightExtent);
+                    case "Error":
+                        return new IggyParseTree.ErrorSymbol(rule, children, leftExtent, rightExtent);
                     default:
                         throw new RuntimeException("Unexpected label:" + label);
                 }

--- a/src/org/iguana/iggy/gen/IggyParseTreeVisitor.java
+++ b/src/org/iguana/iggy/gen/IggyParseTreeVisitor.java
@@ -93,6 +93,8 @@ public interface IggyParseTreeVisitor<T> extends ParseTreeVisitor<T> {
 
     T visitPlusSepSymbol(IggyParseTree.PlusSepSymbol node);
 
+    T visitErrorSymbol(IggyParseTree.ErrorSymbol node);
+
     T visitArguments(IggyParseTree.Arguments node);
 
     T visitCallStatement(IggyParseTree.CallStatement node);

--- a/src/org/iguana/parser/IguanaParser.java
+++ b/src/org/iguana/parser/IguanaParser.java
@@ -36,6 +36,8 @@ import org.iguana.parsetree.DefaultParseTreeBuilder;
 import org.iguana.parsetree.ParseTreeBuilder;
 import org.iguana.parsetree.ParseTreeNode;
 import org.iguana.result.ParserResultOps;
+import org.iguana.result.Result;
+import org.iguana.sppf.NonPackedNode;
 import org.iguana.sppf.NonterminalNode;
 import org.iguana.traversal.AmbiguousSPPFToParseTreeVisitor;
 import org.iguana.traversal.DefaultSPPFToParseTreeVisitor;
@@ -83,13 +85,13 @@ public class IguanaParser extends IguanaRecognizer {
     public void parse(Input input, Nonterminal start, ParseOptions options) {
         clear();
         this.input = input;
-        IguanaRuntime<?> runtime = new IguanaRuntime<>(config, parserResultOps);
+        IguanaRuntime<NonPackedNode> runtime = new IguanaRuntime<>(config, parserResultOps);
         long startTime = System.nanoTime();
         this.sppf = (NonterminalNode) runtime.run(input, start, grammarGraph, options.getMap(), options.isGlobal());
         long endTime = System.nanoTime();
         this.statistics = runtime.getStatistics();
-        this.parseError = runtime.getParseError();
-        if (parseError != null) {
+        if (sppf == null) {
+            this.parseError = runtime.getParseError();
             throw new ParseErrorException(parseError);
         } else {
             System.out.println("Parsing finished in " + (endTime - startTime) / 1000_000 + "ms.");

--- a/src/org/iguana/parser/IguanaRecognizer.java
+++ b/src/org/iguana/parser/IguanaRecognizer.java
@@ -23,7 +23,7 @@ public class IguanaRecognizer {
     protected final GrammarGraph grammarGraph;
     protected final Configuration config;
 
-    protected ParseError parseError;
+    protected ParseError<?> parseError;
     protected RecognizerStatistics statistics;
 
     protected final RuntimeGrammar finalGrammar;
@@ -63,18 +63,20 @@ public class IguanaRecognizer {
     public boolean recognize(Input input, Nonterminal start, Map<String, Object> map, boolean global) {
         clear();
         IguanaRuntime<RecognizerResult> runtime = new IguanaRuntime<>(config, recognizerResultOps);
-        RecognizerResult root = (RecognizerResult) runtime.run(input, start, grammarGraph, map, global);
-        this.parseError = runtime.getParseError();
+        RecognizerResult result = runtime.run(input, start, grammarGraph, map, global);
         this.statistics = runtime.getStatistics();
-        if (root == null) return false;
-        return root.getRightExtent() == input.length() - 1;
+        if (result == null) {
+            this.parseError = runtime.getParseError();
+            return false;
+        }
+        return true;
     }
 
     public RecognizerStatistics getStatistics() {
         return statistics;
     }
 
-    public ParseError getParseError() {
+    public ParseError<?> getParseError() {
         return parseError;
     }
 

--- a/src/org/iguana/parser/IguanaRuntime.java
+++ b/src/org/iguana/parser/IguanaRuntime.java
@@ -137,7 +137,7 @@ public class IguanaRuntime<T extends Result> {
      */
     public void recordParseError(int i, GrammarSlot slot, GSSNode<T> gssNode, String description) {
         List<GSSEdge<T>> errorSlots = new ArrayList<>();
-        getErrorSlot(gssNode, errorSlots);
+        getErrorSlot(gssNode, errorSlots, new HashSet<>());
         for (GSSEdge<T> edge : errorSlots) {
             BodyGrammarSlot returnSlot = edge.getReturnSlot();
             T result = edge instanceof DummyGSSEdge<?> ? resultOps.dummy() : edge.getResult();
@@ -153,7 +153,9 @@ public class IguanaRuntime<T extends Result> {
         }
     }
 
-    private void getErrorSlot(GSSNode<T> gssNode, List<GSSEdge<T>> result) {
+    private void getErrorSlot(GSSNode<T> gssNode, List<GSSEdge<T>> result, Set<GSSNode<T>> visited) {
+        if (visited.contains(gssNode)) return;
+        visited.add(gssNode);
         if (gssNode == null) return;
         for (GSSEdge<T> edge : gssNode.getGSSEdges()) {
             if (edge.getReturnSlot() != null) {
@@ -162,7 +164,7 @@ public class IguanaRuntime<T extends Result> {
                     return;
                 }
             }
-            getErrorSlot(edge.getDestination(), result);
+            getErrorSlot(edge.getDestination(), result, visited);
         }
     }
 

--- a/src/org/iguana/parser/IguanaRuntime.java
+++ b/src/org/iguana/parser/IguanaRuntime.java
@@ -1,15 +1,13 @@
 package org.iguana.parser;
 
-import org.iguana.grammar.slot.*;
-import org.iguana.grammar.symbol.Nonterminal;
-import org.iguana.util.Tuple;
-import org.iguana.utils.input.Input;
 import org.iguana.datadependent.ast.Expression;
 import org.iguana.datadependent.ast.Statement;
 import org.iguana.datadependent.env.Environment;
 import org.iguana.datadependent.env.GLLEvaluator;
 import org.iguana.datadependent.env.IEvaluatorContext;
 import org.iguana.grammar.GrammarGraph;
+import org.iguana.grammar.slot.*;
+import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.gss.*;
 import org.iguana.parser.descriptor.Descriptor;
 import org.iguana.result.ParserResultOps;
@@ -17,23 +15,12 @@ import org.iguana.result.Result;
 import org.iguana.result.ResultOps;
 import org.iguana.util.Configuration;
 import org.iguana.util.ParserLogger;
+import org.iguana.utils.input.Input;
 
 import java.util.*;
 import java.util.function.Function;
 
 public class IguanaRuntime<T extends Result> {
-
-    /**
-     * The grammar slot at which a getParserTree error is occurred.
-     */
-    private GrammarSlot errorSlot;
-
-    /**
-     * The last input index at which an error is occurred.
-     */
-    private int errorIndex;
-
-    private String errorDescription;
 
     private final Deque<Descriptor<T>> descriptorPool;
 
@@ -47,9 +34,7 @@ public class IguanaRuntime<T extends Result> {
 
     private final ResultOps<T> resultOps;
 
-    private boolean hasParseError;
-
-    private Input input;
+    private final PriorityQueue<ParseError<T>> parseErrors;
 
     public IguanaRuntime(Configuration config, ResultOps<T> resultOps) {
         this.config = config;
@@ -57,17 +42,16 @@ public class IguanaRuntime<T extends Result> {
         this.descriptorsStack = new ArrayDeque<>(512);
         this.descriptorPool = new ArrayDeque<>(512);
         this.ctx = GLLEvaluator.getEvaluatorContext(config);
+        this.parseErrors = new PriorityQueue<>((error1, error2) -> error2.getInputIndex() - error1.getInputIndex());
     }
 
-    public Result run(Input input, Nonterminal start, GrammarGraph grammarGraph, Map<String, Object> map, boolean global) {
-        this.input = input;
+    public T run(Input input, Nonterminal start, GrammarGraph grammarGraph, Map<String, Object> map, boolean global) {
+        clearState(grammarGraph);
 
         IEvaluatorContext ctx = getEvaluatorContext();
 
         if (global)
             map.forEach(ctx::declareGlobalVariable);
-
-        int inputLength = input.length() - 1;
 
         Environment env = ctx.getEmptyEnvironment();
 
@@ -113,43 +97,62 @@ public class IguanaRuntime<T extends Result> {
             scheduleDescriptor(slot, startGSSNode, getResultOps().dummy(), env);
         }
 
+        T result = runParserLoop(startGSSNode, input);
+        if (result != null) {
+            return result;
+        }
+
+        PriorityQueue<ParseError<T>> copyParseErrors = new PriorityQueue<>(parseErrors);
+        while (!copyParseErrors.isEmpty()) {
+            recoverFromError(copyParseErrors.poll(), input);
+            T recoveryResult = runParserLoop(startGSSNode, input);
+            if (recoveryResult != null) {
+                return recoveryResult;
+            }
+        }
+
+        return result;
+    }
+
+    private T runParserLoop(StartGSSNode<T> startGSSNode, Input input) {
         while (hasDescriptor()) {
             Descriptor<T> descriptor = nextDescriptor();
             logger.processDescriptor(descriptor);
             descriptor.getGrammarSlot().execute(input, descriptor.getGSSNode(), descriptor.getResult(), descriptor.getEnv(), this);
         }
 
+        int inputLength = input.length() - 1;
+        T result = startGSSNode.getResult(inputLength);
+        // If there was a successful parse (covering the whole input range) for the start symbol
+        if (result != null && result.getRightExtent() == inputLength) {
+            return result;
+        }
+        return null;
+    }
+
+    private void clearState(GrammarGraph grammarGraph) {
         grammarGraph.clear();
         descriptorPool.clear();
         descriptorsStack.clear();
-
-        T result = startGSSNode.getResult(inputLength);
-        hasParseError = result == null || result.getRightExtent() != input.length() - 1;
-        return result;
+        parseErrors.clear();
     }
 
-    /**
-     * Replaces the previously reported getParserTree error with the new one if the
-     * inputIndex of the new getParserTree error is greater than the previous one. In
-     * other words, we throw away an error if we find an error which happens at
-     * the next position of input.
-     *
-     */
-    public void recordParseError(int i, GrammarSlot slot, GSSNode<T> gssNode, String description) {
+    public void recordParseError(int inputIndex, Input input, GrammarSlot slot, GSSNode<T> gssNode, String description) {
+        // GrammarSlot slot, int inputIndex, int lineNumber, int columnNumber, String description
+        ParseError<T> error = new ParseError<>(slot, gssNode, inputIndex, input.getLineNumber(inputIndex), input.getColumnNumber(inputIndex), description);
+        parseErrors.add(error);
+        logger.error(error);
+    }
+
+    private void recoverFromError(ParseError<T> error, Input input) {
         List<GSSEdge<T>> errorSlots = new ArrayList<>();
-        getErrorSlot(gssNode, errorSlots, new HashSet<>());
+        getErrorSlot(error.getGssNode(), errorSlots, new HashSet<>());
         for (GSSEdge<T> edge : errorSlots) {
             BodyGrammarSlot returnSlot = edge.getReturnSlot();
             T result = edge instanceof DummyGSSEdge<?> ? resultOps.dummy() : edge.getResult();
             Environment env = edge.getEnv();
             ErrorTransition errorTransition = (ErrorTransition) returnSlot.getOutTransition();
             errorTransition.handleError(input, edge.getDestination(), result, env, this);
-        }
-        if (i >= this.errorIndex) {
-            this.errorIndex = i;
-            this.errorSlot = slot;
-            this.errorDescription = description;
-            logger.error(errorSlot, errorIndex, errorDescription);
         }
     }
 
@@ -255,9 +258,9 @@ public class IguanaRuntime<T extends Result> {
         return values;
     }
 
-    public ParseError getParseError() {
-        if (!hasParseError) return null;
-        return new ParseError(errorSlot, errorIndex, input.getLineNumber(errorIndex), input.getColumnNumber(errorIndex), errorDescription);
+    public ParseError<T> getParseError() {
+        if (parseErrors.isEmpty()) return null;
+        return parseErrors.peek();
     }
 
     public RecognizerStatistics getStatistics() {

--- a/src/org/iguana/parser/ParseError.java
+++ b/src/org/iguana/parser/ParseError.java
@@ -28,24 +28,28 @@
 package org.iguana.parser;
 
 import org.iguana.grammar.slot.GrammarSlot;
+import org.iguana.gss.GSSNode;
+import org.iguana.result.Result;
 
 import java.util.Objects;
 
 
-public class ParseError {
+public class ParseError<T extends Result> {
 
 	private final GrammarSlot slot;
 	private final int inputIndex;
 	private final int lineNumber;
 	private final int columnNumber;
+	private final GSSNode<T> gssNode;
 	private final String description;
 
-    public ParseError(GrammarSlot slot, int inputIndex, int lineNumber, int columnNumber, String description) {
+    public ParseError(GrammarSlot slot, GSSNode<T> gssNode, int inputIndex, int lineNumber, int columnNumber, String description) {
 		this.slot = slot;
 		this.inputIndex = inputIndex;
 		this.lineNumber = lineNumber;
 		this.columnNumber = columnNumber;
 		this.description = description;
+		this.gssNode = gssNode;
     }
 	
 	public int getInputIndex() {
@@ -64,14 +68,22 @@ public class ParseError {
 		return columnNumber;
 	}
 
+	public String getDescription() {
+		return description;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) return true;
 		if (!(obj instanceof ParseError)) return false;
-		ParseError other = (ParseError) obj;
+		ParseError<?> other = (ParseError<?>) obj;
 		return inputIndex == other.inputIndex &&
 			   lineNumber == other.lineNumber &&
 			   columnNumber == other.columnNumber;
+	}
+
+	public GSSNode<T> getGssNode() {
+		return gssNode;
 	}
 
 	@Override

--- a/src/org/iguana/parser/ParseErrorException.java
+++ b/src/org/iguana/parser/ParseErrorException.java
@@ -2,13 +2,13 @@ package org.iguana.parser;
 
 public class ParseErrorException extends RuntimeException {
 
-    private final ParseError parseError;
+    private final ParseError<?> parseError;
 
-    public ParseErrorException(ParseError parseError) {
+    public ParseErrorException(ParseError<?> parseError) {
         this.parseError = parseError;
     }
 
-    public ParseError getParseError() {
+    public ParseError<?> getParseError() {
         return parseError;
     }
 

--- a/src/org/iguana/parsetree/DefaultParseTreeBuilder.java
+++ b/src/org/iguana/parsetree/DefaultParseTreeBuilder.java
@@ -66,4 +66,9 @@ public class DefaultParseTreeBuilder implements ParseTreeBuilder<ParseTreeNode> 
     public ParseTreeNode startNode(Start symbol, List<ParseTreeNode> children, int leftExtent, int rightExtent) {
         return new StartNode(symbol, children, leftExtent, rightExtent);
     }
+
+    @Override
+    public ParseTreeNode errorNode(int leftExtent, int rightExtent) {
+        return new ErrorNode(leftExtent, rightExtent, input);
+    }
 }

--- a/src/org/iguana/parsetree/ErrorNode.java
+++ b/src/org/iguana/parsetree/ErrorNode.java
@@ -1,0 +1,59 @@
+package org.iguana.parsetree;
+
+import org.iguana.utils.input.Input;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ErrorNode implements ParseTreeNode {
+
+    private final Input input;
+    private final int start;
+    private final int end;
+
+    public ErrorNode(int start, int end, Input input) {
+        this.start = start;
+        this.end = end;
+        this.input = input;
+    }
+
+    @Override
+    public int getStart() {
+        return start;
+    }
+
+    @Override
+    public int getEnd() {
+        return end;
+    }
+
+    @Override
+    public String getName() {
+        return "Error";
+    }
+
+    @Override
+    public Object getGrammarDefinition() {
+        return null;
+    }
+
+    @Override
+    public String getText() {
+        return input.subString(start, end);
+    }
+
+    @Override
+    public <T> Object accept(ParseTreeVisitor<T> visitor) {
+        return visitor.visitErrorNode(this);
+    }
+
+    @Override
+    public List<ParseTreeNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return false;
+    }
+}

--- a/src/org/iguana/parsetree/ErrorNode.java
+++ b/src/org/iguana/parsetree/ErrorNode.java
@@ -4,6 +4,7 @@ import org.iguana.utils.input.Input;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ErrorNode implements ParseTreeNode {
 
@@ -55,5 +56,18 @@ public class ErrorNode implements ParseTreeNode {
     @Override
     public boolean hasChildren() {
         return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ErrorNode)) return false;
+        ErrorNode errorNode = (ErrorNode) o;
+        return start == errorNode.start && end == errorNode.end;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
     }
 }

--- a/src/org/iguana/parsetree/ParseTreeBuilder.java
+++ b/src/org/iguana/parsetree/ParseTreeBuilder.java
@@ -25,6 +25,8 @@ public interface ParseTreeBuilder<T> {
 
     T startNode(Start symbol, List<T> children, int leftExtent, int rightExtent);
 
+    T errorNode(int leftExtent, int rightExtent);
+
     default T metaSymbolNode(Symbol symbol, List<T> children, int leftExtent, int rightExtent) {
         if (symbol instanceof Star) {
             return starNode((Star) symbol, children, leftExtent, rightExtent);

--- a/src/org/iguana/parsetree/ParseTreeVisitor.java
+++ b/src/org/iguana/parsetree/ParseTreeVisitor.java
@@ -20,6 +20,8 @@ public interface ParseTreeVisitor<T> {
         return null;
     }
 
+    default T visitErrorNode(ErrorNode node) { return null; }
+
     default List<T> visitStarNode(MetaSymbolNode.StarNode node) {
         return visitStarOrPlusNode(node);
     }

--- a/src/org/iguana/result/ParserResultOps.java
+++ b/src/org/iguana/result/ParserResultOps.java
@@ -85,6 +85,11 @@ public class ParserResultOps implements ResultOps<NonPackedNode> {
     }
 
     @Override
+    public NonPackedNode error(BodyGrammarSlot slot, int start, int end) {
+        return new ErrorNode(slot, start, end);
+    }
+
+    @Override
     public NonPackedNode merge(NonPackedNode current, NonPackedNode result1, NonPackedNode result2, BodyGrammarSlot slot) {
         if (result1 == dummyNode)
             return result2;

--- a/src/org/iguana/result/RecognizerResult.java
+++ b/src/org/iguana/result/RecognizerResult.java
@@ -30,7 +30,7 @@ class SimpleRecognizerResult implements RecognizerResult {
         return start;
     }
 
-        @Override
+    @Override
     public boolean isDummy() {
         return false;
     }

--- a/src/org/iguana/result/RecognizerResultOps.java
+++ b/src/org/iguana/result/RecognizerResultOps.java
@@ -44,6 +44,11 @@ public class RecognizerResultOps implements ResultOps<RecognizerResult> {
     }
 
     @Override
+    public RecognizerResult error(BodyGrammarSlot slot, int start, int end) {
+        return RecognizerResult.of(start, end);
+    }
+
+    @Override
     public RecognizerResult merge(RecognizerResult current, RecognizerResult result1, RecognizerResult result2, BodyGrammarSlot slot) {
         return result2;
     }

--- a/src/org/iguana/result/ResultOps.java
+++ b/src/org/iguana/result/ResultOps.java
@@ -7,6 +7,7 @@ import org.iguana.grammar.slot.TerminalGrammarSlot;
 public interface ResultOps<T extends Result> {
     T dummy();
     T base(TerminalGrammarSlot slot, int start, int end);
+    T error(BodyGrammarSlot slot, int start, int end);
     T merge(T current, T result1, T result2, BodyGrammarSlot slot);
     T convert(T current, T result, EndGrammarSlot slot, Object value);
 }

--- a/src/org/iguana/sppf/DefaultTerminalNode.java
+++ b/src/org/iguana/sppf/DefaultTerminalNode.java
@@ -4,18 +4,18 @@ import org.iguana.grammar.slot.TerminalGrammarSlot;
 
 public class DefaultTerminalNode extends TerminalNode {
 
-    private final int righExtent;
+    private final int rightExtent;
     private final TerminalGrammarSlot slot;
 
-    public DefaultTerminalNode(TerminalGrammarSlot slot, int leftExtent, int righExtent) {
+    public DefaultTerminalNode(TerminalGrammarSlot slot, int leftExtent, int rightExtent) {
         super(leftExtent);
         this.slot = slot;
-        this.righExtent = righExtent;
+        this.rightExtent = rightExtent;
     }
 
     @Override
     public int getRightExtent() {
-        return righExtent;
+        return rightExtent;
     }
 
     @Override

--- a/src/org/iguana/sppf/ErrorNode.java
+++ b/src/org/iguana/sppf/ErrorNode.java
@@ -1,0 +1,63 @@
+package org.iguana.sppf;
+
+import org.iguana.grammar.slot.BodyGrammarSlot;
+import org.iguana.grammar.slot.GrammarSlot;
+import org.iguana.traversal.SPPFVisitor;
+
+public class ErrorNode extends NonPackedNode {
+
+    private final BodyGrammarSlot slot;
+    private final int leftExtent;
+    private final int rightExtent;
+
+    public ErrorNode(BodyGrammarSlot slot, int leftExtent, int rightExtent) {
+        this.slot = slot;
+        this.leftExtent = leftExtent;
+        this.rightExtent = rightExtent;
+    }
+
+    @Override
+    public int getRightExtent() {
+        return rightExtent;
+    }
+
+    @Override
+    public SPPFNode getChildAt(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int childrenCount() {
+        return 0;
+    }
+
+    @Override
+    public GrammarSlot getGrammarSlot() {
+        return slot;
+    }
+
+    @Override
+    public int getLeftExtent() {
+        return leftExtent;
+    }
+
+    @Override
+    public <R> R accept(SPPFVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public void setAmbiguous(boolean ambiguous) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAmbiguous() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PackedNode getFirstPackedNode() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/org/iguana/traversal/AmbiguousSPPFToParseTreeVisitor.java
+++ b/src/org/iguana/traversal/AmbiguousSPPFToParseTreeVisitor.java
@@ -11,8 +11,8 @@ import org.iguana.result.ParserResultOps;
 import org.iguana.sppf.*;
 import org.iguana.traversal.exception.CyclicGrammarException;
 
-import java.util.*;
 import java.util.List;
+import java.util.*;
 
 import static java.util.Collections.singletonList;
 import static org.iguana.parsetree.VisitResult.*;
@@ -23,7 +23,7 @@ public class AmbiguousSPPFToParseTreeVisitor<T> implements SPPFVisitor<VisitResu
     private final Set<NonterminalNode> visitedNodes;
     private final Map<NonPackedNode, VisitResult> convertedNodes;
     private final boolean ignoreLayout;
-    private ParserResultOps resultOps;
+    private final ParserResultOps resultOps;
 
     private final VisitResult.CreateParseTreeVisitor<T> createNodeVisitor;
 
@@ -180,6 +180,11 @@ public class AmbiguousSPPFToParseTreeVisitor<T> implements SPPFVisitor<VisitResu
         }
 
         return left.merge(right);
+    }
+
+    @Override
+    public VisitResult visit(ErrorNode node) {
+        return VisitResult.single(parseTreeBuilder.errorNode(node.getLeftExtent(), node.getRightExtent()));
     }
 
 }

--- a/src/org/iguana/traversal/DefaultSPPFToParseTreeVisitor.java
+++ b/src/org/iguana/traversal/DefaultSPPFToParseTreeVisitor.java
@@ -115,6 +115,11 @@ public class DefaultSPPFToParseTreeVisitor<T> implements SPPFVisitor<T> {
         throw new RuntimeException("Should not visit packed nodes.");
     }
 
+    @Override
+    public T visit(ErrorNode node) {
+        return parseTreeBuilder.errorNode(node.getLeftExtent(), node.getRightExtent());
+    }
+
     private T convertBasicAndLayout(BodyGrammarSlot slot, NonPackedNode child, int leftExtent, int rightExtent) {
         int bodySize = slot.getRule().getBody().size();
         if (ignoreLayout) { // Layout is insert between symbols in the body of a rule

--- a/src/org/iguana/traversal/ISymbolVisitor.java
+++ b/src/org/iguana/traversal/ISymbolVisitor.java
@@ -40,7 +40,7 @@ public interface ISymbolVisitor<T> {
 
 	default T visit(CodeHolder codeHolder) { return null; }
 
-	default T visit(Error error) { return null; }
+	T visit(Error error);
 
 	T visit(Conditional conditional);
 	

--- a/src/org/iguana/traversal/ISymbolVisitor.java
+++ b/src/org/iguana/traversal/ISymbolVisitor.java
@@ -28,6 +28,7 @@
 package org.iguana.traversal;
 
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 
 public interface ISymbolVisitor<T> {
 	
@@ -38,6 +39,8 @@ public interface ISymbolVisitor<T> {
 	T visit(Code code);
 
 	default T visit(CodeHolder codeHolder) { return null; }
+
+	default T visit(Error error) { return null; }
 
 	T visit(Conditional conditional);
 	

--- a/src/org/iguana/traversal/SPPFVisitor.java
+++ b/src/org/iguana/traversal/SPPFVisitor.java
@@ -27,10 +27,7 @@
 
 package org.iguana.traversal;
 
-import org.iguana.sppf.IntermediateNode;
-import org.iguana.sppf.NonterminalNode;
-import org.iguana.sppf.PackedNode;
-import org.iguana.sppf.TerminalNode;
+import org.iguana.sppf.*;
 
 /**
  * Provides a standard interface based on the command pattern for
@@ -49,5 +46,7 @@ public interface SPPFVisitor<T> {
 	Object visit(IntermediateNode node);
 
 	Object visit(PackedNode node);
+
+	T visit(ErrorNode node);
 
 }

--- a/src/org/iguana/traversal/SymbolToSymbolVisitor.java
+++ b/src/org/iguana/traversal/SymbolToSymbolVisitor.java
@@ -5,6 +5,7 @@ import org.iguana.grammar.condition.DataDependentCondition;
 import org.iguana.grammar.condition.PositionalCondition;
 import org.iguana.grammar.condition.RegularExpressionCondition;
 import org.iguana.grammar.symbol.Alt;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.Opt;
 import org.iguana.grammar.symbol.Plus;
 import org.iguana.grammar.symbol.Star;
@@ -187,6 +188,11 @@ public interface SymbolToSymbolVisitor extends ISymbolVisitor<Symbol>, IConditio
     @Override
     default Symbol visit(CodeHolder symbol) {
         return symbol;
+    }
+
+    @Override
+    default Symbol visit(Error error) {
+        return error;
     }
 
     default Symbol visitSymbol(Symbol symbol) {

--- a/src/org/iguana/traversal/idea/CollectRegularExpressions.java
+++ b/src/org/iguana/traversal/idea/CollectRegularExpressions.java
@@ -27,6 +27,7 @@
 
 package org.iguana.traversal.idea;
 
+import org.iguana.grammar.symbol.Error;
 import org.iguana.regex.RegularExpression;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.runtime.RuntimeRule;
@@ -76,6 +77,11 @@ public class CollectRegularExpressions implements ISymbolVisitor<Void> {
     @Override
     public Void visit(Code symbol) {
         return symbol.getSymbol().accept(this);
+    }
+
+    @Override
+    public Void visit(Error error) {
+        return null;
     }
 
     @Override

--- a/src/org/iguana/traversal/idea/GenerateElements.java
+++ b/src/org/iguana/traversal/idea/GenerateElements.java
@@ -29,6 +29,7 @@ package org.iguana.traversal.idea;
 
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.traversal.ISymbolVisitor;
 
 import java.io.File;
@@ -247,6 +248,11 @@ public class GenerateElements {
         @Override
         public String visit(Code symbol) {
             return symbol.getSymbol().accept(this);
+        }
+
+        @Override
+        public String visit(Error error) {
+            return null;
         }
 
         @Override
@@ -715,6 +721,11 @@ public class GenerateElements {
         @Override
         public String visit(Code symbol) {
             return symbol.getSymbol().accept(this);
+        }
+
+        @Override
+        public String visit(Error error) {
+            return null;
         }
 
         @Override

--- a/src/org/iguana/traversal/idea/Names.java
+++ b/src/org/iguana/traversal/idea/Names.java
@@ -32,6 +32,7 @@ import org.iguana.grammar.runtime.Recursion;
 import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.symbol.*;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.transformation.GrammarTransformation;
 import org.iguana.traversal.ISymbolVisitor;
 
@@ -103,6 +104,11 @@ public class Names implements GrammarTransformation {
         @Override
         public Symbol visit(Code symbol) {
             return Code.code(visitSymbol(symbol.getSymbol()), symbol.getStatements());
+        }
+
+        @Override
+        public Symbol visit(Error error) {
+            return error;
         }
 
         @Override

--- a/src/org/iguana/util/ParserLogger.java
+++ b/src/org/iguana/util/ParserLogger.java
@@ -1,20 +1,20 @@
 package org.iguana.util;
 
-import org.iguana.utils.logging.IguanaLogger;
-import org.iguana.utils.logging.JavaUtilIguanaLogger;
-import org.iguana.utils.logging.LogLevel;
-import org.iguana.grammar.slot.GrammarSlot;
 import org.iguana.gss.GSSEdge;
 import org.iguana.gss.GSSNode;
+import org.iguana.parser.ParseError;
 import org.iguana.parser.descriptor.Descriptor;
 import org.iguana.result.Result;
 import org.iguana.sppf.*;
+import org.iguana.utils.logging.IguanaLogger;
+import org.iguana.utils.logging.JavaUtilIguanaLogger;
+import org.iguana.utils.logging.LogLevel;
 
 import java.util.Arrays;
 
 public class ParserLogger {
 
-    private static ParserLogger instance = new ParserLogger();
+    private static final ParserLogger instance = new ParserLogger();
 
     public static ParserLogger getInstance() {
         return instance;
@@ -114,8 +114,8 @@ public class ParserLogger {
         if (logEnabled) logger.log("Pop %s, %d, %s, %s", gssNode, inputIndex, child, value);
     }
 
-    public void error(GrammarSlot slot, int i, String errorDescription) {
-        if (logEnabled) logger.log("Error recorded at %s %d %s", slot, i, errorDescription);
+    public void error(ParseError error) {
+        if (logEnabled) logger.log("Error recorded at %s %d %s", error.getGrammarSlot(), error.getInputIndex(), error.getDescription());
     }
 
     public <T extends Result> void processDescriptor(Descriptor<T> descriptor) {

--- a/src/org/iguana/util/serialization/JsonSerializer.java
+++ b/src/org/iguana/util/serialization/JsonSerializer.java
@@ -27,6 +27,7 @@ import org.iguana.grammar.symbol.Opt;
 import org.iguana.grammar.symbol.Plus;
 import org.iguana.grammar.symbol.Star;
 import org.iguana.grammar.symbol.*;
+import org.iguana.gss.GSSNode;
 import org.iguana.parser.ParseError;
 import org.iguana.parsetree.*;
 import org.iguana.regex.*;
@@ -964,10 +965,12 @@ public class JsonSerializer {
         @JsonIgnore GrammarSlot slot;
         ParseErrorMixIn(
             @JsonProperty("slot") GrammarSlot slot,
+            @JsonProperty("gssNode") GSSNode<?> gssNode,
             @JsonProperty("inputIndex") int inputIndex,
             @JsonProperty("lineNumber") int lineNumber,
             @JsonProperty("columnNumber") int columnNumber,
             @JsonProperty("description") String description) { }
+        @JsonIgnore GSSNode<?> gssNode;
     }
 
     abstract static class PrecedenceLevelMixIn {

--- a/src/org/iguana/util/serialization/JsonSerializer.java
+++ b/src/org/iguana/util/serialization/JsonSerializer.java
@@ -22,6 +22,7 @@ import org.iguana.grammar.runtime.RuntimeRule;
 import org.iguana.grammar.slot.GrammarSlot;
 import org.iguana.grammar.slot.NonterminalNodeType;
 import org.iguana.grammar.symbol.Alt;
+import org.iguana.grammar.symbol.Error;
 import org.iguana.grammar.symbol.Opt;
 import org.iguana.grammar.symbol.Plus;
 import org.iguana.grammar.symbol.Star;
@@ -75,6 +76,7 @@ public class JsonSerializer {
         mapper.addMixIn(Offside.class, OffsideMixIn.class);
         mapper.addMixIn(Align.class, AlignMixIn.class);
         mapper.addMixIn(Ignore.class, IgnoreMixIn.class);
+        mapper.addMixIn(Error.class, ErrorMixIn.class);
 
         mapper.addMixIn(AbstractAttrs.class, AbstractAttrsMixIn.class);
 
@@ -177,6 +179,7 @@ public class JsonSerializer {
         mapper.addMixIn(MetaSymbolNode.StartNode.class, StartNodeMixIn.class);
         mapper.addMixIn(DefaultTerminalNode.class, DefaultTerminalNodeMixIn.class);
         mapper.addMixIn(KeywordTerminalNode.class, KeywordTerminalNodeMixIn.class);
+        mapper.addMixIn(ErrorNode.class, ErrorNodeMixIn.class);
 
         mapper.addMixIn(ParseError.class, ParseErrorMixIn.class);
 
@@ -312,7 +315,8 @@ public class JsonSerializer {
         @JsonSubTypes.Type(value=IfThenElse.class, name="IfThenElse"),
         @JsonSubTypes.Type(value=Offside.class, name="Offside"),
         @JsonSubTypes.Type(value=Align.class, name="Align"),
-        @JsonSubTypes.Type(value=Ignore.class, name="Ignore")
+        @JsonSubTypes.Type(value=Ignore.class, name="Ignore"),
+        @JsonSubTypes.Type(value=Error.class, name="Error")
     })
     abstract static class SymbolMixIn { }
 
@@ -350,7 +354,8 @@ public class JsonSerializer {
         @JsonSubTypes.Type(value=MetaSymbolNode.GroupNode.class, name="GroupNode"),
         @JsonSubTypes.Type(value=MetaSymbolNode.OptionNode.class, name="OptionNode"),
         @JsonSubTypes.Type(value=MetaSymbolNode.AltNode.class, name="AltNode"),
-        @JsonSubTypes.Type(value=MetaSymbolNode.StartNode.class, name="StartNode")
+        @JsonSubTypes.Type(value=MetaSymbolNode.StartNode.class, name="StartNode"),
+        @JsonSubTypes.Type(value=ErrorNode.class, name="ErrorNode")
     })
     abstract static class ParseTreeNodeMixIn { }
 
@@ -359,7 +364,7 @@ public class JsonSerializer {
             @JsonProperty("terminal") Terminal terminal,
             @JsonProperty("start") int start,
             @JsonProperty("end") int end,
-            @JsonProperty("ignore") Input input
+            @JsonProperty("input") Input input
         ) { }
         @JsonIgnore
         Input input;
@@ -371,6 +376,16 @@ public class JsonSerializer {
             @JsonProperty("start") int start,
             @JsonProperty("end") int end
         ) { }
+    }
+
+    abstract static class ErrorNodeMixIn {
+        ErrorNodeMixIn(
+            @JsonProperty("start") int start,
+            @JsonProperty("end") int end,
+            @JsonProperty("input") Input input
+        ) { }
+        @JsonIgnore
+        Input input;
     }
 
     abstract static class NonterminalNodeMixIn {
@@ -500,6 +515,11 @@ public class JsonSerializer {
 
     @JsonDeserialize(builder = Ignore.Builder.class)
     abstract static class IgnoreMixIn extends AbstractSymbolMixIn { }
+
+    abstract static class ErrorMixIn extends AbstractAttrsMixIn {
+        @JsonCreator
+        public abstract Error getInstance();
+    }
 
     @JsonDeserialize(builder = org.iguana.regex.Seq.Builder.class)
     abstract static class SeqMixIn extends AbstractRegularExpressionMixIn { }

--- a/src/org/iguana/util/visualization/ParseTreeToDot.java
+++ b/src/org/iguana/util/visualization/ParseTreeToDot.java
@@ -103,6 +103,15 @@ public class ParseTreeToDot implements ParseTreeVisitor<Integer> {
         return id;
     }
 
+    @Override
+    public Integer visitErrorNode(ErrorNode node) {
+        String text = input.subString(node.getStart(), node.getEnd());
+        String label = String.format("(Error, %d, %d): \"%s\"", node.getStart(), node.getEnd(), text);
+        int id = nextId();
+        dotGraph.addNode(newNode(id, label).setShape(DotGraph.Shape.ROUNDED_RECTANGLE));
+        return id;
+    }
+
     private int id = 0;
     private int nextId() {
         return id++;

--- a/src/org/iguana/util/visualization/SPPFToDot.java
+++ b/src/org/iguana/util/visualization/SPPFToDot.java
@@ -139,7 +139,19 @@ public class SPPFToDot implements SPPFVisitor<Void>  {
 		visitChildren(node);
 		return null;
 	}
-	
+
+	@Override
+	public Void visit(ErrorNode node) {
+		if(!visited.contains(node)) {
+			visited.add(node);
+			String matchedInput = input.subString(node.getLeftExtent(), node.getRightExtent());
+			String label = String.format("(Error, %d, %d): \"%s\"", node.getLeftExtent(), node.getRightExtent(), matchedInput);
+			dotGraph.addNode(newNode(getId(node), label));
+		}
+
+		return null;
+	}
+
 	private void addEdgesToChildren(SPPFNode node) {
 	    for (int i = 0; i < node.childrenCount(); i++) {
             addEdgeToChild(node, node.getChildAt(i));

--- a/src/resources/Iguana.iggy
+++ b/src/resources/Iguana.iggy
@@ -64,6 +64,7 @@ Symbol
   | charClass:CharClass                                          %CharClass
   | "{" sym:Symbol sep:Symbol+ "}" "*"                           %StarSep
   | "{" sym:Symbol sep:Symbol+ "}" "+"                           %PlusSep
+  | "error"                                                      %Error
 
 Arguments
   = "(" {Expression ","}* ")"
@@ -209,3 +210,4 @@ regex Keywords
   | "lexical"
   | "grammar"
   | "global"
+  | "error"

--- a/src/resources/iggy.json
+++ b/src/resources/iggy.json
@@ -2681,6 +2681,61 @@
                 }
               ],
               "associativity" : "UNDEFINED"
+            },
+            {
+              "seqs" : [
+                {
+                  "symbols" : [
+                    {
+                      "kind" : "Terminal",
+                      "name" : "'error'",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ],
+                      "nodeType" : "Literal",
+                      "regex" : {
+                        "kind" : "regex.Seq",
+                        "lookaheads" : [ ],
+                        "lookbehinds" : [ ],
+                        "symbols" : [
+                          {
+                            "kind" : "Char",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "val" : 101
+                          },
+                          {
+                            "kind" : "Char",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "val" : 114
+                          },
+                          {
+                            "kind" : "Char",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "val" : 114
+                          },
+                          {
+                            "kind" : "Char",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "val" : 111
+                          },
+                          {
+                            "kind" : "Char",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "val" : 114
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "associativity" : "UNDEFINED",
+                  "label" : "Error"
+                }
+              ],
+              "associativity" : "UNDEFINED"
             }
           ]
         }
@@ -7017,6 +7072,43 @@
               "val" : 108
             }
           ]
+        },
+        {
+          "kind" : "regex.Seq",
+          "lookaheads" : [ ],
+          "lookbehinds" : [ ],
+          "symbols" : [
+            {
+              "kind" : "Char",
+              "lookaheads" : [ ],
+              "lookbehinds" : [ ],
+              "val" : 101
+            },
+            {
+              "kind" : "Char",
+              "lookaheads" : [ ],
+              "lookbehinds" : [ ],
+              "val" : 114
+            },
+            {
+              "kind" : "Char",
+              "lookaheads" : [ ],
+              "lookbehinds" : [ ],
+              "val" : 114
+            },
+            {
+              "kind" : "Char",
+              "lookaheads" : [ ],
+              "lookbehinds" : [ ],
+              "val" : 111
+            },
+            {
+              "kind" : "Char",
+              "lookaheads" : [ ],
+              "lookbehinds" : [ ],
+              "val" : 114
+            }
+          ]
         }
       ]
     }
@@ -7684,6 +7776,43 @@
           "lookaheads" : [ ],
           "lookbehinds" : [ ],
           "val" : 101
+        }
+      ]
+    },
+    "error" : {
+      "kind" : "regex.Seq",
+      "lookaheads" : [ ],
+      "lookbehinds" : [ ],
+      "symbols" : [
+        {
+          "kind" : "Char",
+          "lookaheads" : [ ],
+          "lookbehinds" : [ ],
+          "val" : 101
+        },
+        {
+          "kind" : "Char",
+          "lookaheads" : [ ],
+          "lookbehinds" : [ ],
+          "val" : 114
+        },
+        {
+          "kind" : "Char",
+          "lookaheads" : [ ],
+          "lookbehinds" : [ ],
+          "val" : 114
+        },
+        {
+          "kind" : "Char",
+          "lookaheads" : [ ],
+          "lookbehinds" : [ ],
+          "val" : 111
+        },
+        {
+          "kind" : "Char",
+          "lookaheads" : [ ],
+          "lookbehinds" : [ ],
+          "val" : 114
         }
       ]
     },

--- a/test/org/iguana/ParserTest.java
+++ b/test/org/iguana/ParserTest.java
@@ -1,0 +1,70 @@
+package org.iguana;
+
+import org.iguana.grammar.symbol.Symbol;
+
+public class ParserTest {
+
+    private final String grammar;
+    private final String input;
+    private final Symbol startSymbol;
+    private final boolean verifyParseTree;
+
+    private ParserTest(ParserTestBuilder builder) {
+        this.grammar = builder.grammar;
+        this.input = builder.input;
+        this.startSymbol = builder.startSymbol;
+        this.verifyParseTree = builder.verifyParseTree;
+    }
+
+    public String getGrammar() {
+        return grammar;
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public boolean verifyParseTree() {
+        return verifyParseTree;
+    }
+
+    public Symbol getStartSymbol() {
+        return startSymbol;
+    }
+
+    public static ParserTestBuilder newTest() {
+        return new ParserTestBuilder();
+    }
+
+    public static class ParserTestBuilder {
+        private String grammar;
+        private String input;
+        private Symbol startSymbol;
+        private boolean verifyParseTree;
+
+        public ParserTestBuilder setGrammar(String grammar) {
+            this.grammar = grammar;
+            return this;
+        }
+
+        public ParserTestBuilder setInput(String input) {
+            this.input = input;
+            return this;
+        }
+
+        public ParserTestBuilder setStartSymbol(Symbol startSymbol) {
+            this.startSymbol = startSymbol;
+            return this;
+        }
+
+        public ParserTestBuilder verifyParseTree() {
+            verifyParseTree = true;
+            return this;
+        }
+
+        public ParserTest build() {
+            if (startSymbol == null) throw new IllegalStateException("startSymbol cannot be null");
+            return new ParserTest(this);
+        }
+    }
+}

--- a/test/org/iguana/parser/ParserTestRunner.java
+++ b/test/org/iguana/parser/ParserTestRunner.java
@@ -1,0 +1,86 @@
+package org.iguana.parser;
+
+import org.iguana.ParserTest;
+import org.iguana.grammar.Grammar;
+import org.iguana.iggy.IggyParserUtils;
+import org.iguana.parsetree.ParseTreeNode;
+import org.iguana.util.serialization.JsonSerializer;
+import org.iguana.utils.input.Input;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class ParserTestRunner {
+
+    private static boolean REGENERATE_FILES = false;
+
+    static {
+        String regenerate = System.getenv("REGENERATE");
+        if (regenerate != null && regenerate.equals("true")) {
+            REGENERATE_FILES = true;
+        }
+    }
+
+    protected String testName;
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        testName = testInfo.getTestMethod().get().getName();
+    }
+
+    private Path getTestDirectory() {
+        Path path = Path.of("test/resources/tests")
+            .resolve(this.getClass().getSimpleName())
+            .resolve(testName);
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return path;
+    }
+
+    protected void run(ParserTest parserTest) {
+        Grammar grammar = IggyParserUtils.fromIggyGrammar(parserTest.getGrammar());
+        Input input = Input.fromString(parserTest.getInput());
+        IguanaParser parser = new IguanaParser(grammar);
+        try {
+            parser.parse(input, parserTest.getStartSymbol());
+        } catch (ParseErrorException e) {
+            throw e;
+        }
+        if (parserTest.verifyParseTree()) {
+            verifyParseTree(parser.getParseTree());
+        }
+    }
+
+    private void verifyParseTree(ParseTreeNode actualParseTreeNode) {
+        Path parseTreePath = getTestDirectory().resolve("parse_tree.json");
+        if (REGENERATE_FILES || !Files.exists(parseTreePath)) {
+            record(actualParseTreeNode, parseTreePath);
+        } else {
+            ParseTreeNode expectedParseTreeNode;
+            try {
+                expectedParseTreeNode = JsonSerializer.deserialize(Files.readString(parseTreePath), ParseTreeNode.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            assertEquals(expectedParseTreeNode, actualParseTreeNode);
+        }
+    }
+
+    private static void record(Object obj, Path path) {
+        String json = JsonSerializer.serialize(obj);
+        try {
+            Files.writeString(path, json);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/org/iguana/parser/error/ErrorRecoveryTest.java
+++ b/test/org/iguana/parser/error/ErrorRecoveryTest.java
@@ -1,0 +1,26 @@
+package org.iguana.parser.error;
+
+import org.iguana.grammar.Grammar;
+import org.iguana.grammar.runtime.RuntimeGrammar;
+import org.iguana.grammar.symbol.Nonterminal;
+import org.iguana.grammar.transformation.GrammarTransformer;
+import org.iguana.parser.IguanaParser;
+import org.iguana.utils.input.Input;
+import org.junit.jupiter.api.Test;
+
+import static org.iguana.iggy.IggyParserUtils.fromIggyGrammar;
+
+public class ErrorRecoveryTest {
+
+    @Test
+    public void test() {
+        String grammarText =
+            "program = stmt+\n" +
+            "stmt = expr error ';'\n" +
+            "expr = expr '*' expr > expr '+' expr | [0-9]+\n";
+
+        Grammar grammar = fromIggyGrammar(grammarText);
+        IguanaParser parser = new IguanaParser(grammar);
+        parser.parse(Input.fromString("1+2;1+3;1*4+2;"), Nonterminal.withName("program"));
+    }
+}

--- a/test/org/iguana/parser/error/ErrorRecoveryTest.java
+++ b/test/org/iguana/parser/error/ErrorRecoveryTest.java
@@ -7,17 +7,89 @@ import org.junit.jupiter.api.Test;
 
 public class ErrorRecoveryTest extends ParserTestRunner {
 
-    @Test
-    public void test1() throws Exception {
-        String grammarText =
-            "program = stmt+\n" +
-                "stmt = expr error ';'\n" +
-                "expr = expr '*' expr > expr '+' expr | [0-9]+\n";
+    String grammar =
+        "program = stmt+\n" +
+        "stmt = expr error ';' | '{' stmt+ error '}' \n" +
+        "expr = expr '*' expr > expr '+' expr | [0-9]+\n";
 
+    @Test
+    public void test1() {
         ParserTest test = ParserTest.newTest()
-            .setGrammar(grammarText)
+            .setGrammar(grammar)
             .setStartSymbol(Nonterminal.withName("program"))
             .setInput("1/3;")
+            .verifyParseTree()
+            .build();
+
+        run(test);
+    }
+
+    @Test
+    public void test2() {
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammar)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("1+2;1/3;1*3;")
+            .verifyParseTree()
+            .build();
+
+        run(test);
+    }
+
+    @Test
+    public void test3() {
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammar)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("{1+2}")
+            .verifyParseTree()
+            .build();
+
+        run(test);
+    }
+
+    @Test
+    public void test4() {
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammar)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("{1+21/3}")
+            .verifyParseTree()
+            .build();
+
+        run(test);
+    }
+
+    @Test
+    public void test5() {
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammar)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("{1/2;}")
+            .verifyParseTree()
+            .build();
+
+        run(test);
+    }
+
+    @Test
+    public void test6() {
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammar)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("{1/2;3*4;}")
+            .verifyParseTree()
+            .build();
+
+        run(test);
+    }
+
+    @Test
+    public void test7() {
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammar)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("{1/2;3+4}")
             .verifyParseTree()
             .build();
 

--- a/test/org/iguana/parser/error/ErrorRecoveryTest.java
+++ b/test/org/iguana/parser/error/ErrorRecoveryTest.java
@@ -1,32 +1,33 @@
 package org.iguana.parser.error;
 
+import org.iguana.ParserTest;
 import org.iguana.grammar.Grammar;
-import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.symbol.Nonterminal;
-import org.iguana.grammar.transformation.GrammarTransformer;
 import org.iguana.parser.IguanaParser;
+import org.iguana.parser.ParserTestRunner;
 import org.iguana.util.visualization.ParseTreeToDot;
-import org.iguana.util.visualization.SPPFToDot;
 import org.iguana.utils.input.Input;
 import org.iguana.utils.visualization.DotGraph;
 import org.junit.jupiter.api.Test;
 
 import static org.iguana.iggy.IggyParserUtils.fromIggyGrammar;
 
-public class ErrorRecoveryTest {
+public class ErrorRecoveryTest extends ParserTestRunner {
 
     @Test
-    public void test() throws Exception {
+    public void test1() throws Exception {
         String grammarText =
-            "program = stmt\n" +
-            "stmt = expr error ';'\n" +
-            "expr = expr '*' expr > expr '+' expr | [0-9]+\n";
+            "program = stmt+\n" +
+                "stmt = expr error ';'\n" +
+                "expr = expr '*' expr > expr '+' expr | [0-9]+\n";
 
-        Grammar grammar = fromIggyGrammar(grammarText);
-        IguanaParser parser = new IguanaParser(grammar);
-        Input input = Input.fromString("1/3;");
-        parser.parse(input, Nonterminal.withName("program"));
-        DotGraph parseTreeDotGraph = ParseTreeToDot.getDotGraph(parser.getParseTree(), input);
-        parseTreeDotGraph.generate("/Users/afroozeh/error.pdf");
+        ParserTest test = ParserTest.newTest()
+            .setGrammar(grammarText)
+            .setStartSymbol(Nonterminal.withName("program"))
+            .setInput("1/3;")
+            .verifyParseTree()
+            .build();
+
+        run(test);
     }
 }

--- a/test/org/iguana/parser/error/ErrorRecoveryTest.java
+++ b/test/org/iguana/parser/error/ErrorRecoveryTest.java
@@ -5,7 +5,10 @@ import org.iguana.grammar.runtime.RuntimeGrammar;
 import org.iguana.grammar.symbol.Nonterminal;
 import org.iguana.grammar.transformation.GrammarTransformer;
 import org.iguana.parser.IguanaParser;
+import org.iguana.util.visualization.ParseTreeToDot;
+import org.iguana.util.visualization.SPPFToDot;
 import org.iguana.utils.input.Input;
+import org.iguana.utils.visualization.DotGraph;
 import org.junit.jupiter.api.Test;
 
 import static org.iguana.iggy.IggyParserUtils.fromIggyGrammar;
@@ -13,14 +16,17 @@ import static org.iguana.iggy.IggyParserUtils.fromIggyGrammar;
 public class ErrorRecoveryTest {
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         String grammarText =
-            "program = stmt+\n" +
+            "program = stmt\n" +
             "stmt = expr error ';'\n" +
             "expr = expr '*' expr > expr '+' expr | [0-9]+\n";
 
         Grammar grammar = fromIggyGrammar(grammarText);
         IguanaParser parser = new IguanaParser(grammar);
-        parser.parse(Input.fromString("1+2;1+3;1*4+2;"), Nonterminal.withName("program"));
+        Input input = Input.fromString("1/3;");
+        parser.parse(input, Nonterminal.withName("program"));
+        DotGraph parseTreeDotGraph = ParseTreeToDot.getDotGraph(parser.getParseTree(), input);
+        parseTreeDotGraph.generate("/Users/afroozeh/error.pdf");
     }
 }

--- a/test/org/iguana/parser/error/ErrorRecoveryTest.java
+++ b/test/org/iguana/parser/error/ErrorRecoveryTest.java
@@ -1,16 +1,9 @@
 package org.iguana.parser.error;
 
 import org.iguana.ParserTest;
-import org.iguana.grammar.Grammar;
 import org.iguana.grammar.symbol.Nonterminal;
-import org.iguana.parser.IguanaParser;
 import org.iguana.parser.ParserTestRunner;
-import org.iguana.util.visualization.ParseTreeToDot;
-import org.iguana.utils.input.Input;
-import org.iguana.utils.visualization.DotGraph;
 import org.junit.jupiter.api.Test;
-
-import static org.iguana.iggy.IggyParserUtils.fromIggyGrammar;
 
 public class ErrorRecoveryTest extends ParserTestRunner {
 

--- a/test/resources/grammars/datadependent/examples/Test3/final_grammar.json
+++ b/test/resources/grammars/datadependent/examples/Test3/final_grammar.json
@@ -3029,6 +3029,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "expr",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/examples/Test4/final_grammar.json
+++ b/test/resources/grammars/datadependent/examples/Test4/final_grammar.json
@@ -4038,6 +4038,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "Exp",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/examples/Test4/result2.json
+++ b/test/resources/grammars/datadependent/examples/Test4/result2.json
@@ -2,5 +2,5 @@
   "inputIndex" : 60,
   "lineNumber" : 5,
   "columnNumber" : 4,
-  "description" : "[f(i,ind,fst,o1.lExt)]"
+  "description" : "Match failed"
 }

--- a/test/resources/grammars/datadependent/examples/Test5/final_grammar.json
+++ b/test/resources/grammars/datadependent/examples/Test5/final_grammar.json
@@ -5133,6 +5133,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "Expression",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/excepts/Test1/final_grammar.json
+++ b/test/resources/grammars/datadependent/excepts/Test1/final_grammar.json
@@ -724,6 +724,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test1/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test1/final_grammar.json
@@ -494,6 +494,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test2/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test2/final_grammar.json
@@ -494,6 +494,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test3/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test3/final_grammar.json
@@ -569,6 +569,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test4/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test4/final_grammar.json
@@ -770,6 +770,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test5/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test5/final_grammar.json
@@ -1010,6 +1010,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test5a/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test5a/final_grammar.json
@@ -1055,6 +1055,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test6/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test6/final_grammar.json
@@ -929,6 +929,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test7/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test7/final_grammar.json
@@ -1434,6 +1434,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test7/result3.json
+++ b/test/resources/grammars/datadependent/indirect/Test7/result3.json
@@ -2,5 +2,5 @@
   "inputIndex" : 6,
   "lineNumber" : 1,
   "columnNumber" : 7,
-  "description" : "[1 >= p]"
+  "description" : "[p != 2 && 2 >= p]"
 }

--- a/test/resources/grammars/datadependent/indirect/Test8/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test8/final_grammar.json
@@ -667,6 +667,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/indirect/Test9/final_grammar.json
+++ b/test/resources/grammars/datadependent/indirect/Test9/final_grammar.json
@@ -728,6 +728,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/datadependent/offside/Test2/result2.json
+++ b/test/resources/grammars/datadependent/offside/Test2/result2.json
@@ -2,5 +2,5 @@
   "inputIndex" : 85,
   "lineNumber" : 10,
   "columnNumber" : 3,
-  "description" : "[f(i,ind,fst,o1.lExt)]"
+  "description" : "Expected [\\uFFFFFFFF] but was +"
 }

--- a/test/resources/grammars/datadependent/state/Test4/final_grammar.json
+++ b/test/resources/grammars/datadependent/state/Test4/final_grammar.json
@@ -595,6 +595,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "state" : [

--- a/test/resources/grammars/datadependent/state/Test5/final_grammar.json
+++ b/test/resources/grammars/datadependent/state/Test5/final_grammar.json
@@ -722,6 +722,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "state" : [

--- a/test/resources/grammars/gamma/Test3/result3.json
+++ b/test/resources/grammars/gamma/Test3/result3.json
@@ -10068,53 +10068,647 @@
               },
               "children" : [
                 {
-                  "kind" : "NonterminalNode",
-                  "rule" : {
-                    "head" : {
-                      "kind" : "Nonterminal",
-                      "name" : "S",
-                      "preConditions" : [ ],
-                      "postConditions" : [ ]
+                  "kind" : "AmbiguityNode",
+                  "alternatives" : [
+                    {
+                      "kind" : "AmbiguityNode",
+                      "alternatives" : [
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              },
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              }
+                            ],
+                            "recursion" : "LEFT_RIGHT_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : 1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  },
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  }
+                                ],
+                                "recursion" : "LEFT_RIGHT_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : 1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 0,
+                                      "end" : 1
+                                    }
+                                  ],
+                                  "start" : 0,
+                                  "end" : 1
+                                },
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 1,
+                                      "end" : 2
+                                    }
+                                  ],
+                                  "start" : 1,
+                                  "end" : 2
+                                }
+                              ],
+                              "start" : 0,
+                              "end" : 2
+                            },
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  }
+                                ],
+                                "recursion" : "NON_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : -1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "KeywordTerminalNode",
+                                  "terminal" : {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  },
+                                  "start" : 2,
+                                  "end" : 3
+                                }
+                              ],
+                              "start" : 2,
+                              "end" : 3
+                            }
+                          ],
+                          "start" : 0,
+                          "end" : 3
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              },
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              }
+                            ],
+                            "recursion" : "LEFT_RIGHT_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : 1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  }
+                                ],
+                                "recursion" : "NON_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : -1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "KeywordTerminalNode",
+                                  "terminal" : {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  },
+                                  "start" : 0,
+                                  "end" : 1
+                                }
+                              ],
+                              "start" : 0,
+                              "end" : 1
+                            },
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  },
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  }
+                                ],
+                                "recursion" : "LEFT_RIGHT_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : 1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 1,
+                                      "end" : 2
+                                    }
+                                  ],
+                                  "start" : 1,
+                                  "end" : 2
+                                },
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 2,
+                                      "end" : 3
+                                    }
+                                  ],
+                                  "start" : 2,
+                                  "end" : 3
+                                }
+                              ],
+                              "start" : 1,
+                              "end" : 3
+                            }
+                          ],
+                          "start" : 0,
+                          "end" : 3
+                        }
+                      ]
                     },
-                    "body" : [
-                      {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ]
-                      },
-                      {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ]
-                      }
-                    ],
-                    "recursion" : "LEFT_RIGHT_REC",
-                    "irecursion" : "NON_REC",
-                    "leftEnd" : "",
-                    "rightEnd" : "",
-                    "leftEnds" : [ ],
-                    "rightEnds" : [ ],
-                    "associativity" : "UNDEFINED",
-                    "precedence" : 1,
-                    "precedenceLevel" : {
-                      "lhs" : 1,
-                      "rhs" : 1,
-                      "undefined" : 1,
-                      "hasPrefixUnary" : false,
-                      "hasPostfixUnary" : false,
-                      "hasPrefixUnaryBelow" : false,
-                      "prefixUnaryBelow" : [ ],
-                      "hasPostfixUnaryBelow" : false,
-                      "postfixUnaryBelow" : [ ],
-                      "index" : 2,
-                      "containsAssociativityGroup" : false,
-                      "assoc_lhs" : -1,
-                      "assoc_rhs" : -1
-                    }
-                  },
-                  "children" : [
                     {
                       "kind" : "NonterminalNode",
                       "rule" : {
@@ -10126,27 +10720,32 @@
                         },
                         "body" : [
                           {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
+                            "kind" : "Nonterminal",
+                            "name" : "S",
                             "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
+                            "postConditions" : [ ]
+                          },
+                          {
+                            "kind" : "Nonterminal",
+                            "name" : "S",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ]
+                          },
+                          {
+                            "kind" : "Nonterminal",
+                            "name" : "S",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ]
                           }
                         ],
-                        "recursion" : "NON_REC",
+                        "recursion" : "LEFT_RIGHT_REC",
                         "irecursion" : "NON_REC",
                         "leftEnd" : "",
                         "rightEnd" : "",
                         "leftEnds" : [ ],
                         "rightEnds" : [ ],
                         "associativity" : "UNDEFINED",
-                        "precedence" : -1,
+                        "precedence" : 1,
                         "precedenceLevel" : {
                           "lhs" : 1,
                           "rhs" : 1,
@@ -10165,101 +10764,223 @@
                       },
                       "children" : [
                         {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
                             }
                           },
+                          "children" : [
+                            {
+                              "kind" : "KeywordTerminalNode",
+                              "terminal" : {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              },
+                              "start" : 0,
+                              "end" : 1
+                            }
+                          ],
                           "start" : 0,
                           "end" : 1
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "KeywordTerminalNode",
+                              "terminal" : {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              },
+                              "start" : 1,
+                              "end" : 2
+                            }
+                          ],
+                          "start" : 1,
+                          "end" : 2
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "KeywordTerminalNode",
+                              "terminal" : {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              },
+                              "start" : 2,
+                              "end" : 3
+                            }
+                          ],
+                          "start" : 2,
+                          "end" : 3
                         }
                       ],
                       "start" : 0,
-                      "end" : 1
-                    },
-                    {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          }
-                        ],
-                        "recursion" : "NON_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : -1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
-                        }
-                      },
-                      "children" : [
-                        {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          },
-                          "start" : 1,
-                          "end" : 2
-                        }
-                      ],
-                      "start" : 1,
-                      "end" : 2
+                      "end" : 3
                     }
-                  ],
-                  "start" : 0,
-                  "end" : 2
+                  ]
                 },
                 {
                   "kind" : "NonterminalNode",
@@ -10272,26 +10993,27 @@
                     },
                     "body" : [
                       {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
+                        "kind" : "Terminal",
+                        "name" : "'b'",
                         "preConditions" : [ ],
-                        "postConditions" : [ ]
-                      },
-                      {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ]
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 98
+                        }
                       }
                     ],
-                    "recursion" : "LEFT_RIGHT_REC",
+                    "recursion" : "NON_REC",
                     "irecursion" : "NON_REC",
                     "leftEnd" : "",
                     "rightEnd" : "",
                     "leftEnds" : [ ],
                     "rightEnds" : [ ],
                     "associativity" : "UNDEFINED",
-                    "precedence" : 1,
+                    "precedence" : -1,
                     "precedenceLevel" : {
                       "lhs" : 1,
                       "rhs" : 1,
@@ -10310,149 +11032,25 @@
                   },
                   "children" : [
                     {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          }
-                        ],
-                        "recursion" : "NON_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : -1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
+                      "kind" : "KeywordTerminalNode",
+                      "terminal" : {
+                        "kind" : "Terminal",
+                        "name" : "'b'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 98
                         }
                       },
-                      "children" : [
-                        {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          },
-                          "start" : 2,
-                          "end" : 3
-                        }
-                      ],
-                      "start" : 2,
-                      "end" : 3
-                    },
-                    {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          }
-                        ],
-                        "recursion" : "NON_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : -1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
-                        }
-                      },
-                      "children" : [
-                        {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          },
-                          "start" : 3,
-                          "end" : 4
-                        }
-                      ],
                       "start" : 3,
                       "end" : 4
                     }
                   ],
-                  "start" : 2,
+                  "start" : 3,
                   "end" : 4
                 },
                 {
@@ -11044,53 +11642,647 @@
               },
               "children" : [
                 {
-                  "kind" : "NonterminalNode",
-                  "rule" : {
-                    "head" : {
-                      "kind" : "Nonterminal",
-                      "name" : "S",
-                      "preConditions" : [ ],
-                      "postConditions" : [ ]
+                  "kind" : "AmbiguityNode",
+                  "alternatives" : [
+                    {
+                      "kind" : "AmbiguityNode",
+                      "alternatives" : [
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              },
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              }
+                            ],
+                            "recursion" : "LEFT_RIGHT_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : 1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  },
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  }
+                                ],
+                                "recursion" : "LEFT_RIGHT_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : 1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 0,
+                                      "end" : 1
+                                    }
+                                  ],
+                                  "start" : 0,
+                                  "end" : 1
+                                },
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 1,
+                                      "end" : 2
+                                    }
+                                  ],
+                                  "start" : 1,
+                                  "end" : 2
+                                }
+                              ],
+                              "start" : 0,
+                              "end" : 2
+                            },
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  }
+                                ],
+                                "recursion" : "NON_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : -1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "KeywordTerminalNode",
+                                  "terminal" : {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  },
+                                  "start" : 2,
+                                  "end" : 3
+                                }
+                              ],
+                              "start" : 2,
+                              "end" : 3
+                            }
+                          ],
+                          "start" : 0,
+                          "end" : 3
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              },
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "S",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ]
+                              }
+                            ],
+                            "recursion" : "LEFT_RIGHT_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : 1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  }
+                                ],
+                                "recursion" : "NON_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : -1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "KeywordTerminalNode",
+                                  "terminal" : {
+                                    "kind" : "Terminal",
+                                    "name" : "'b'",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Literal",
+                                    "regex" : {
+                                      "kind" : "Char",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "val" : 98
+                                    }
+                                  },
+                                  "start" : 0,
+                                  "end" : 1
+                                }
+                              ],
+                              "start" : 0,
+                              "end" : 1
+                            },
+                            {
+                              "kind" : "NonterminalNode",
+                              "rule" : {
+                                "head" : {
+                                  "kind" : "Nonterminal",
+                                  "name" : "S",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ]
+                                },
+                                "body" : [
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  },
+                                  {
+                                    "kind" : "Nonterminal",
+                                    "name" : "S",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ]
+                                  }
+                                ],
+                                "recursion" : "LEFT_RIGHT_REC",
+                                "irecursion" : "NON_REC",
+                                "leftEnd" : "",
+                                "rightEnd" : "",
+                                "leftEnds" : [ ],
+                                "rightEnds" : [ ],
+                                "associativity" : "UNDEFINED",
+                                "precedence" : 1,
+                                "precedenceLevel" : {
+                                  "lhs" : 1,
+                                  "rhs" : 1,
+                                  "undefined" : 1,
+                                  "hasPrefixUnary" : false,
+                                  "hasPostfixUnary" : false,
+                                  "hasPrefixUnaryBelow" : false,
+                                  "prefixUnaryBelow" : [ ],
+                                  "hasPostfixUnaryBelow" : false,
+                                  "postfixUnaryBelow" : [ ],
+                                  "index" : 2,
+                                  "containsAssociativityGroup" : false,
+                                  "assoc_lhs" : -1,
+                                  "assoc_rhs" : -1
+                                }
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 1,
+                                      "end" : 2
+                                    }
+                                  ],
+                                  "start" : 1,
+                                  "end" : 2
+                                },
+                                {
+                                  "kind" : "NonterminalNode",
+                                  "rule" : {
+                                    "head" : {
+                                      "kind" : "Nonterminal",
+                                      "name" : "S",
+                                      "preConditions" : [ ],
+                                      "postConditions" : [ ]
+                                    },
+                                    "body" : [
+                                      {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      }
+                                    ],
+                                    "recursion" : "NON_REC",
+                                    "irecursion" : "NON_REC",
+                                    "leftEnd" : "",
+                                    "rightEnd" : "",
+                                    "leftEnds" : [ ],
+                                    "rightEnds" : [ ],
+                                    "associativity" : "UNDEFINED",
+                                    "precedence" : -1,
+                                    "precedenceLevel" : {
+                                      "lhs" : 1,
+                                      "rhs" : 1,
+                                      "undefined" : 1,
+                                      "hasPrefixUnary" : false,
+                                      "hasPostfixUnary" : false,
+                                      "hasPrefixUnaryBelow" : false,
+                                      "prefixUnaryBelow" : [ ],
+                                      "hasPostfixUnaryBelow" : false,
+                                      "postfixUnaryBelow" : [ ],
+                                      "index" : 2,
+                                      "containsAssociativityGroup" : false,
+                                      "assoc_lhs" : -1,
+                                      "assoc_rhs" : -1
+                                    }
+                                  },
+                                  "children" : [
+                                    {
+                                      "kind" : "KeywordTerminalNode",
+                                      "terminal" : {
+                                        "kind" : "Terminal",
+                                        "name" : "'b'",
+                                        "preConditions" : [ ],
+                                        "postConditions" : [ ],
+                                        "nodeType" : "Literal",
+                                        "regex" : {
+                                          "kind" : "Char",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "val" : 98
+                                        }
+                                      },
+                                      "start" : 2,
+                                      "end" : 3
+                                    }
+                                  ],
+                                  "start" : 2,
+                                  "end" : 3
+                                }
+                              ],
+                              "start" : 1,
+                              "end" : 3
+                            }
+                          ],
+                          "start" : 0,
+                          "end" : 3
+                        }
+                      ]
                     },
-                    "body" : [
-                      {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ]
-                      },
-                      {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ]
-                      }
-                    ],
-                    "recursion" : "LEFT_RIGHT_REC",
-                    "irecursion" : "NON_REC",
-                    "leftEnd" : "",
-                    "rightEnd" : "",
-                    "leftEnds" : [ ],
-                    "rightEnds" : [ ],
-                    "associativity" : "UNDEFINED",
-                    "precedence" : 1,
-                    "precedenceLevel" : {
-                      "lhs" : 1,
-                      "rhs" : 1,
-                      "undefined" : 1,
-                      "hasPrefixUnary" : false,
-                      "hasPostfixUnary" : false,
-                      "hasPrefixUnaryBelow" : false,
-                      "prefixUnaryBelow" : [ ],
-                      "hasPostfixUnaryBelow" : false,
-                      "postfixUnaryBelow" : [ ],
-                      "index" : 2,
-                      "containsAssociativityGroup" : false,
-                      "assoc_lhs" : -1,
-                      "assoc_rhs" : -1
-                    }
-                  },
-                  "children" : [
                     {
                       "kind" : "NonterminalNode",
                       "rule" : {
@@ -11102,27 +12294,32 @@
                         },
                         "body" : [
                           {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
+                            "kind" : "Nonterminal",
+                            "name" : "S",
                             "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
+                            "postConditions" : [ ]
+                          },
+                          {
+                            "kind" : "Nonterminal",
+                            "name" : "S",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ]
+                          },
+                          {
+                            "kind" : "Nonterminal",
+                            "name" : "S",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ]
                           }
                         ],
-                        "recursion" : "NON_REC",
+                        "recursion" : "LEFT_RIGHT_REC",
                         "irecursion" : "NON_REC",
                         "leftEnd" : "",
                         "rightEnd" : "",
                         "leftEnds" : [ ],
                         "rightEnds" : [ ],
                         "associativity" : "UNDEFINED",
-                        "precedence" : -1,
+                        "precedence" : 1,
                         "precedenceLevel" : {
                           "lhs" : 1,
                           "rhs" : 1,
@@ -11141,101 +12338,223 @@
                       },
                       "children" : [
                         {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
                             }
                           },
+                          "children" : [
+                            {
+                              "kind" : "KeywordTerminalNode",
+                              "terminal" : {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              },
+                              "start" : 0,
+                              "end" : 1
+                            }
+                          ],
                           "start" : 0,
                           "end" : 1
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "KeywordTerminalNode",
+                              "terminal" : {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              },
+                              "start" : 1,
+                              "end" : 2
+                            }
+                          ],
+                          "start" : 1,
+                          "end" : 2
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "S",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "KeywordTerminalNode",
+                              "terminal" : {
+                                "kind" : "Terminal",
+                                "name" : "'b'",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Literal",
+                                "regex" : {
+                                  "kind" : "Char",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "val" : 98
+                                }
+                              },
+                              "start" : 2,
+                              "end" : 3
+                            }
+                          ],
+                          "start" : 2,
+                          "end" : 3
                         }
                       ],
                       "start" : 0,
-                      "end" : 1
-                    },
-                    {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          }
-                        ],
-                        "recursion" : "NON_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : -1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
-                        }
-                      },
-                      "children" : [
-                        {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          },
-                          "start" : 1,
-                          "end" : 2
-                        }
-                      ],
-                      "start" : 1,
-                      "end" : 2
+                      "end" : 3
                     }
-                  ],
-                  "start" : 0,
-                  "end" : 2
+                  ]
                 },
                 {
                   "kind" : "NonterminalNode",
@@ -11248,26 +12567,27 @@
                     },
                     "body" : [
                       {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
+                        "kind" : "Terminal",
+                        "name" : "'b'",
                         "preConditions" : [ ],
-                        "postConditions" : [ ]
-                      },
-                      {
-                        "kind" : "Nonterminal",
-                        "name" : "S",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ]
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 98
+                        }
                       }
                     ],
-                    "recursion" : "LEFT_RIGHT_REC",
+                    "recursion" : "NON_REC",
                     "irecursion" : "NON_REC",
                     "leftEnd" : "",
                     "rightEnd" : "",
                     "leftEnds" : [ ],
                     "rightEnds" : [ ],
                     "associativity" : "UNDEFINED",
-                    "precedence" : 1,
+                    "precedence" : -1,
                     "precedenceLevel" : {
                       "lhs" : 1,
                       "rhs" : 1,
@@ -11286,149 +12606,25 @@
                   },
                   "children" : [
                     {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          }
-                        ],
-                        "recursion" : "NON_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : -1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
+                      "kind" : "KeywordTerminalNode",
+                      "terminal" : {
+                        "kind" : "Terminal",
+                        "name" : "'b'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 98
                         }
                       },
-                      "children" : [
-                        {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          },
-                          "start" : 2,
-                          "end" : 3
-                        }
-                      ],
-                      "start" : 2,
-                      "end" : 3
-                    },
-                    {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          }
-                        ],
-                        "recursion" : "NON_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : -1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
-                        }
-                      },
-                      "children" : [
-                        {
-                          "kind" : "KeywordTerminalNode",
-                          "terminal" : {
-                            "kind" : "Terminal",
-                            "name" : "'b'",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ],
-                            "nodeType" : "Literal",
-                            "regex" : {
-                              "kind" : "Char",
-                              "lookaheads" : [ ],
-                              "lookbehinds" : [ ],
-                              "val" : 98
-                            }
-                          },
-                          "start" : 3,
-                          "end" : 4
-                        }
-                      ],
                       "start" : 3,
                       "end" : 4
                     }
                   ],
-                  "start" : 2,
+                  "start" : 3,
                   "end" : 4
                 },
                 {
@@ -12020,921 +13216,6 @@
               },
               "children" : [
                 {
-                  "kind" : "AmbiguityNode",
-                  "alternatives" : [
-                    {
-                      "kind" : "AmbiguityNode",
-                      "alternatives" : [
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              },
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              }
-                            ],
-                            "recursion" : "LEFT_RIGHT_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : 1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  },
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  }
-                                ],
-                                "recursion" : "LEFT_RIGHT_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : 1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 0,
-                                      "end" : 1
-                                    }
-                                  ],
-                                  "start" : 0,
-                                  "end" : 1
-                                },
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 1,
-                                      "end" : 2
-                                    }
-                                  ],
-                                  "start" : 1,
-                                  "end" : 2
-                                }
-                              ],
-                              "start" : 0,
-                              "end" : 2
-                            },
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  }
-                                ],
-                                "recursion" : "NON_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : -1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "KeywordTerminalNode",
-                                  "terminal" : {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  },
-                                  "start" : 2,
-                                  "end" : 3
-                                }
-                              ],
-                              "start" : 2,
-                              "end" : 3
-                            }
-                          ],
-                          "start" : 0,
-                          "end" : 3
-                        },
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              },
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              }
-                            ],
-                            "recursion" : "LEFT_RIGHT_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : 1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  }
-                                ],
-                                "recursion" : "NON_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : -1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "KeywordTerminalNode",
-                                  "terminal" : {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  },
-                                  "start" : 0,
-                                  "end" : 1
-                                }
-                              ],
-                              "start" : 0,
-                              "end" : 1
-                            },
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  },
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  }
-                                ],
-                                "recursion" : "LEFT_RIGHT_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : 1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 1,
-                                      "end" : 2
-                                    }
-                                  ],
-                                  "start" : 1,
-                                  "end" : 2
-                                },
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 2,
-                                      "end" : 3
-                                    }
-                                  ],
-                                  "start" : 2,
-                                  "end" : 3
-                                }
-                              ],
-                              "start" : 1,
-                              "end" : 3
-                            }
-                          ],
-                          "start" : 0,
-                          "end" : 3
-                        }
-                      ]
-                    },
-                    {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Nonterminal",
-                            "name" : "S",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ]
-                          },
-                          {
-                            "kind" : "Nonterminal",
-                            "name" : "S",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ]
-                          },
-                          {
-                            "kind" : "Nonterminal",
-                            "name" : "S",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ]
-                          }
-                        ],
-                        "recursion" : "LEFT_RIGHT_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : 1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
-                        }
-                      },
-                      "children" : [
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              }
-                            ],
-                            "recursion" : "NON_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : -1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "KeywordTerminalNode",
-                              "terminal" : {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              },
-                              "start" : 0,
-                              "end" : 1
-                            }
-                          ],
-                          "start" : 0,
-                          "end" : 1
-                        },
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              }
-                            ],
-                            "recursion" : "NON_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : -1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "KeywordTerminalNode",
-                              "terminal" : {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              },
-                              "start" : 1,
-                              "end" : 2
-                            }
-                          ],
-                          "start" : 1,
-                          "end" : 2
-                        },
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              }
-                            ],
-                            "recursion" : "NON_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : -1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "KeywordTerminalNode",
-                              "terminal" : {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              },
-                              "start" : 2,
-                              "end" : 3
-                            }
-                          ],
-                          "start" : 2,
-                          "end" : 3
-                        }
-                      ],
-                      "start" : 0,
-                      "end" : 3
-                    }
-                  ]
-                },
-                {
                   "kind" : "NonterminalNode",
                   "rule" : {
                     "head" : {
@@ -12945,27 +13226,26 @@
                     },
                     "body" : [
                       {
-                        "kind" : "Terminal",
-                        "name" : "'b'",
+                        "kind" : "Nonterminal",
+                        "name" : "S",
                         "preConditions" : [ ],
-                        "postConditions" : [ ],
-                        "nodeType" : "Literal",
-                        "regex" : {
-                          "kind" : "Char",
-                          "lookaheads" : [ ],
-                          "lookbehinds" : [ ],
-                          "val" : 98
-                        }
+                        "postConditions" : [ ]
+                      },
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "S",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ]
                       }
                     ],
-                    "recursion" : "NON_REC",
+                    "recursion" : "LEFT_RIGHT_REC",
                     "irecursion" : "NON_REC",
                     "leftEnd" : "",
                     "rightEnd" : "",
                     "leftEnds" : [ ],
                     "rightEnds" : [ ],
                     "associativity" : "UNDEFINED",
-                    "precedence" : -1,
+                    "precedence" : 1,
                     "precedenceLevel" : {
                       "lhs" : 1,
                       "rhs" : 1,
@@ -12984,25 +13264,343 @@
                   },
                   "children" : [
                     {
-                      "kind" : "KeywordTerminalNode",
-                      "terminal" : {
-                        "kind" : "Terminal",
-                        "name" : "'b'",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ],
-                        "nodeType" : "Literal",
-                        "regex" : {
-                          "kind" : "Char",
-                          "lookaheads" : [ ],
-                          "lookbehinds" : [ ],
-                          "val" : 98
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
                         }
                       },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 0,
+                          "end" : 1
+                        }
+                      ],
+                      "start" : 0,
+                      "end" : 1
+                    },
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 1,
+                          "end" : 2
+                        }
+                      ],
+                      "start" : 1,
+                      "end" : 2
+                    }
+                  ],
+                  "start" : 0,
+                  "end" : 2
+                },
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "S",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "S",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ]
+                      },
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "S",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ]
+                      }
+                    ],
+                    "recursion" : "LEFT_RIGHT_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : 1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : 1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 2,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 2,
+                          "end" : 3
+                        }
+                      ],
+                      "start" : 2,
+                      "end" : 3
+                    },
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 3,
+                          "end" : 4
+                        }
+                      ],
                       "start" : 3,
                       "end" : 4
                     }
                   ],
-                  "start" : 3,
+                  "start" : 2,
                   "end" : 4
                 },
                 {
@@ -13594,921 +14192,6 @@
               },
               "children" : [
                 {
-                  "kind" : "AmbiguityNode",
-                  "alternatives" : [
-                    {
-                      "kind" : "AmbiguityNode",
-                      "alternatives" : [
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              },
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              }
-                            ],
-                            "recursion" : "LEFT_RIGHT_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : 1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  },
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  }
-                                ],
-                                "recursion" : "LEFT_RIGHT_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : 1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 0,
-                                      "end" : 1
-                                    }
-                                  ],
-                                  "start" : 0,
-                                  "end" : 1
-                                },
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 1,
-                                      "end" : 2
-                                    }
-                                  ],
-                                  "start" : 1,
-                                  "end" : 2
-                                }
-                              ],
-                              "start" : 0,
-                              "end" : 2
-                            },
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  }
-                                ],
-                                "recursion" : "NON_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : -1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "KeywordTerminalNode",
-                                  "terminal" : {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  },
-                                  "start" : 2,
-                                  "end" : 3
-                                }
-                              ],
-                              "start" : 2,
-                              "end" : 3
-                            }
-                          ],
-                          "start" : 0,
-                          "end" : 3
-                        },
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              },
-                              {
-                                "kind" : "Nonterminal",
-                                "name" : "S",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ]
-                              }
-                            ],
-                            "recursion" : "LEFT_RIGHT_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : 1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  }
-                                ],
-                                "recursion" : "NON_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : -1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "KeywordTerminalNode",
-                                  "terminal" : {
-                                    "kind" : "Terminal",
-                                    "name" : "'b'",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ],
-                                    "nodeType" : "Literal",
-                                    "regex" : {
-                                      "kind" : "Char",
-                                      "lookaheads" : [ ],
-                                      "lookbehinds" : [ ],
-                                      "val" : 98
-                                    }
-                                  },
-                                  "start" : 0,
-                                  "end" : 1
-                                }
-                              ],
-                              "start" : 0,
-                              "end" : 1
-                            },
-                            {
-                              "kind" : "NonterminalNode",
-                              "rule" : {
-                                "head" : {
-                                  "kind" : "Nonterminal",
-                                  "name" : "S",
-                                  "preConditions" : [ ],
-                                  "postConditions" : [ ]
-                                },
-                                "body" : [
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  },
-                                  {
-                                    "kind" : "Nonterminal",
-                                    "name" : "S",
-                                    "preConditions" : [ ],
-                                    "postConditions" : [ ]
-                                  }
-                                ],
-                                "recursion" : "LEFT_RIGHT_REC",
-                                "irecursion" : "NON_REC",
-                                "leftEnd" : "",
-                                "rightEnd" : "",
-                                "leftEnds" : [ ],
-                                "rightEnds" : [ ],
-                                "associativity" : "UNDEFINED",
-                                "precedence" : 1,
-                                "precedenceLevel" : {
-                                  "lhs" : 1,
-                                  "rhs" : 1,
-                                  "undefined" : 1,
-                                  "hasPrefixUnary" : false,
-                                  "hasPostfixUnary" : false,
-                                  "hasPrefixUnaryBelow" : false,
-                                  "prefixUnaryBelow" : [ ],
-                                  "hasPostfixUnaryBelow" : false,
-                                  "postfixUnaryBelow" : [ ],
-                                  "index" : 2,
-                                  "containsAssociativityGroup" : false,
-                                  "assoc_lhs" : -1,
-                                  "assoc_rhs" : -1
-                                }
-                              },
-                              "children" : [
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 1,
-                                      "end" : 2
-                                    }
-                                  ],
-                                  "start" : 1,
-                                  "end" : 2
-                                },
-                                {
-                                  "kind" : "NonterminalNode",
-                                  "rule" : {
-                                    "head" : {
-                                      "kind" : "Nonterminal",
-                                      "name" : "S",
-                                      "preConditions" : [ ],
-                                      "postConditions" : [ ]
-                                    },
-                                    "body" : [
-                                      {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      }
-                                    ],
-                                    "recursion" : "NON_REC",
-                                    "irecursion" : "NON_REC",
-                                    "leftEnd" : "",
-                                    "rightEnd" : "",
-                                    "leftEnds" : [ ],
-                                    "rightEnds" : [ ],
-                                    "associativity" : "UNDEFINED",
-                                    "precedence" : -1,
-                                    "precedenceLevel" : {
-                                      "lhs" : 1,
-                                      "rhs" : 1,
-                                      "undefined" : 1,
-                                      "hasPrefixUnary" : false,
-                                      "hasPostfixUnary" : false,
-                                      "hasPrefixUnaryBelow" : false,
-                                      "prefixUnaryBelow" : [ ],
-                                      "hasPostfixUnaryBelow" : false,
-                                      "postfixUnaryBelow" : [ ],
-                                      "index" : 2,
-                                      "containsAssociativityGroup" : false,
-                                      "assoc_lhs" : -1,
-                                      "assoc_rhs" : -1
-                                    }
-                                  },
-                                  "children" : [
-                                    {
-                                      "kind" : "KeywordTerminalNode",
-                                      "terminal" : {
-                                        "kind" : "Terminal",
-                                        "name" : "'b'",
-                                        "preConditions" : [ ],
-                                        "postConditions" : [ ],
-                                        "nodeType" : "Literal",
-                                        "regex" : {
-                                          "kind" : "Char",
-                                          "lookaheads" : [ ],
-                                          "lookbehinds" : [ ],
-                                          "val" : 98
-                                        }
-                                      },
-                                      "start" : 2,
-                                      "end" : 3
-                                    }
-                                  ],
-                                  "start" : 2,
-                                  "end" : 3
-                                }
-                              ],
-                              "start" : 1,
-                              "end" : 3
-                            }
-                          ],
-                          "start" : 0,
-                          "end" : 3
-                        }
-                      ]
-                    },
-                    {
-                      "kind" : "NonterminalNode",
-                      "rule" : {
-                        "head" : {
-                          "kind" : "Nonterminal",
-                          "name" : "S",
-                          "preConditions" : [ ],
-                          "postConditions" : [ ]
-                        },
-                        "body" : [
-                          {
-                            "kind" : "Nonterminal",
-                            "name" : "S",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ]
-                          },
-                          {
-                            "kind" : "Nonterminal",
-                            "name" : "S",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ]
-                          },
-                          {
-                            "kind" : "Nonterminal",
-                            "name" : "S",
-                            "preConditions" : [ ],
-                            "postConditions" : [ ]
-                          }
-                        ],
-                        "recursion" : "LEFT_RIGHT_REC",
-                        "irecursion" : "NON_REC",
-                        "leftEnd" : "",
-                        "rightEnd" : "",
-                        "leftEnds" : [ ],
-                        "rightEnds" : [ ],
-                        "associativity" : "UNDEFINED",
-                        "precedence" : 1,
-                        "precedenceLevel" : {
-                          "lhs" : 1,
-                          "rhs" : 1,
-                          "undefined" : 1,
-                          "hasPrefixUnary" : false,
-                          "hasPostfixUnary" : false,
-                          "hasPrefixUnaryBelow" : false,
-                          "prefixUnaryBelow" : [ ],
-                          "hasPostfixUnaryBelow" : false,
-                          "postfixUnaryBelow" : [ ],
-                          "index" : 2,
-                          "containsAssociativityGroup" : false,
-                          "assoc_lhs" : -1,
-                          "assoc_rhs" : -1
-                        }
-                      },
-                      "children" : [
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              }
-                            ],
-                            "recursion" : "NON_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : -1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "KeywordTerminalNode",
-                              "terminal" : {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              },
-                              "start" : 0,
-                              "end" : 1
-                            }
-                          ],
-                          "start" : 0,
-                          "end" : 1
-                        },
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              }
-                            ],
-                            "recursion" : "NON_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : -1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "KeywordTerminalNode",
-                              "terminal" : {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              },
-                              "start" : 1,
-                              "end" : 2
-                            }
-                          ],
-                          "start" : 1,
-                          "end" : 2
-                        },
-                        {
-                          "kind" : "NonterminalNode",
-                          "rule" : {
-                            "head" : {
-                              "kind" : "Nonterminal",
-                              "name" : "S",
-                              "preConditions" : [ ],
-                              "postConditions" : [ ]
-                            },
-                            "body" : [
-                              {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              }
-                            ],
-                            "recursion" : "NON_REC",
-                            "irecursion" : "NON_REC",
-                            "leftEnd" : "",
-                            "rightEnd" : "",
-                            "leftEnds" : [ ],
-                            "rightEnds" : [ ],
-                            "associativity" : "UNDEFINED",
-                            "precedence" : -1,
-                            "precedenceLevel" : {
-                              "lhs" : 1,
-                              "rhs" : 1,
-                              "undefined" : 1,
-                              "hasPrefixUnary" : false,
-                              "hasPostfixUnary" : false,
-                              "hasPrefixUnaryBelow" : false,
-                              "prefixUnaryBelow" : [ ],
-                              "hasPostfixUnaryBelow" : false,
-                              "postfixUnaryBelow" : [ ],
-                              "index" : 2,
-                              "containsAssociativityGroup" : false,
-                              "assoc_lhs" : -1,
-                              "assoc_rhs" : -1
-                            }
-                          },
-                          "children" : [
-                            {
-                              "kind" : "KeywordTerminalNode",
-                              "terminal" : {
-                                "kind" : "Terminal",
-                                "name" : "'b'",
-                                "preConditions" : [ ],
-                                "postConditions" : [ ],
-                                "nodeType" : "Literal",
-                                "regex" : {
-                                  "kind" : "Char",
-                                  "lookaheads" : [ ],
-                                  "lookbehinds" : [ ],
-                                  "val" : 98
-                                }
-                              },
-                              "start" : 2,
-                              "end" : 3
-                            }
-                          ],
-                          "start" : 2,
-                          "end" : 3
-                        }
-                      ],
-                      "start" : 0,
-                      "end" : 3
-                    }
-                  ]
-                },
-                {
                   "kind" : "NonterminalNode",
                   "rule" : {
                     "head" : {
@@ -14519,27 +14202,26 @@
                     },
                     "body" : [
                       {
-                        "kind" : "Terminal",
-                        "name" : "'b'",
+                        "kind" : "Nonterminal",
+                        "name" : "S",
                         "preConditions" : [ ],
-                        "postConditions" : [ ],
-                        "nodeType" : "Literal",
-                        "regex" : {
-                          "kind" : "Char",
-                          "lookaheads" : [ ],
-                          "lookbehinds" : [ ],
-                          "val" : 98
-                        }
+                        "postConditions" : [ ]
+                      },
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "S",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ]
                       }
                     ],
-                    "recursion" : "NON_REC",
+                    "recursion" : "LEFT_RIGHT_REC",
                     "irecursion" : "NON_REC",
                     "leftEnd" : "",
                     "rightEnd" : "",
                     "leftEnds" : [ ],
                     "rightEnds" : [ ],
                     "associativity" : "UNDEFINED",
-                    "precedence" : -1,
+                    "precedence" : 1,
                     "precedenceLevel" : {
                       "lhs" : 1,
                       "rhs" : 1,
@@ -14558,25 +14240,343 @@
                   },
                   "children" : [
                     {
-                      "kind" : "KeywordTerminalNode",
-                      "terminal" : {
-                        "kind" : "Terminal",
-                        "name" : "'b'",
-                        "preConditions" : [ ],
-                        "postConditions" : [ ],
-                        "nodeType" : "Literal",
-                        "regex" : {
-                          "kind" : "Char",
-                          "lookaheads" : [ ],
-                          "lookbehinds" : [ ],
-                          "val" : 98
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
                         }
                       },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 0,
+                          "end" : 1
+                        }
+                      ],
+                      "start" : 0,
+                      "end" : 1
+                    },
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 1,
+                          "end" : 2
+                        }
+                      ],
+                      "start" : 1,
+                      "end" : 2
+                    }
+                  ],
+                  "start" : 0,
+                  "end" : 2
+                },
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "S",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "S",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ]
+                      },
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "S",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ]
+                      }
+                    ],
+                    "recursion" : "LEFT_RIGHT_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : 1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : 1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 2,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 2,
+                          "end" : 3
+                        }
+                      ],
+                      "start" : 2,
+                      "end" : 3
+                    },
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "S",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          }
+                        ],
+                        "recursion" : "NON_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : -1,
+                        "precedenceLevel" : {
+                          "lhs" : 1,
+                          "rhs" : 1,
+                          "undefined" : 1,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 2,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'b'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 98
+                            }
+                          },
+                          "start" : 3,
+                          "end" : 4
+                        }
+                      ],
                       "start" : 3,
                       "end" : 4
                     }
                   ],
-                  "start" : 3,
+                  "start" : 2,
                   "end" : 4
                 },
                 {

--- a/test/resources/grammars/precedence/Test1/final_grammar.json
+++ b/test/resources/grammars/precedence/Test1/final_grammar.json
@@ -338,6 +338,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test10/final_grammar.json
+++ b/test/resources/grammars/precedence/Test10/final_grammar.json
@@ -520,6 +520,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test11/final_grammar.json
+++ b/test/resources/grammars/precedence/Test11/final_grammar.json
@@ -543,6 +543,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test12/final_grammar.json
+++ b/test/resources/grammars/precedence/Test12/final_grammar.json
@@ -735,6 +735,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test13/final_grammar.json
+++ b/test/resources/grammars/precedence/Test13/final_grammar.json
@@ -970,6 +970,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test14/final_grammar.json
+++ b/test/resources/grammars/precedence/Test14/final_grammar.json
@@ -520,6 +520,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test15/final_grammar.json
+++ b/test/resources/grammars/precedence/Test15/final_grammar.json
@@ -457,6 +457,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test16/final_grammar.json
+++ b/test/resources/grammars/precedence/Test16/final_grammar.json
@@ -373,6 +373,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test17/final_grammar.json
+++ b/test/resources/grammars/precedence/Test17/final_grammar.json
@@ -517,6 +517,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test18/final_grammar.json
+++ b/test/resources/grammars/precedence/Test18/final_grammar.json
@@ -520,6 +520,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test19/final_grammar.json
+++ b/test/resources/grammars/precedence/Test19/final_grammar.json
@@ -625,6 +625,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test2/final_grammar.json
+++ b/test/resources/grammars/precedence/Test2/final_grammar.json
@@ -204,6 +204,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test20/final_grammar.json
+++ b/test/resources/grammars/precedence/Test20/final_grammar.json
@@ -416,6 +416,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test21/final_grammar.json
+++ b/test/resources/grammars/precedence/Test21/final_grammar.json
@@ -454,6 +454,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test22/final_grammar.json
+++ b/test/resources/grammars/precedence/Test22/final_grammar.json
@@ -994,6 +994,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test23/final_grammar.json
+++ b/test/resources/grammars/precedence/Test23/final_grammar.json
@@ -1485,6 +1485,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test24/final_grammar.json
+++ b/test/resources/grammars/precedence/Test24/final_grammar.json
@@ -2702,6 +2702,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test26/final_grammar.json
+++ b/test/resources/grammars/precedence/Test26/final_grammar.json
@@ -520,6 +520,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test27/final_grammar.json
+++ b/test/resources/grammars/precedence/Test27/final_grammar.json
@@ -976,6 +976,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test28/final_grammar.json
+++ b/test/resources/grammars/precedence/Test28/final_grammar.json
@@ -624,6 +624,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test29/final_grammar.json
+++ b/test/resources/grammars/precedence/Test29/final_grammar.json
@@ -538,6 +538,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test3/final_grammar.json
+++ b/test/resources/grammars/precedence/Test3/final_grammar.json
@@ -204,6 +204,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test30/final_grammar.json
+++ b/test/resources/grammars/precedence/Test30/final_grammar.json
@@ -416,6 +416,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test31/final_grammar.json
+++ b/test/resources/grammars/precedence/Test31/final_grammar.json
@@ -520,6 +520,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test32/final_grammar.json
+++ b/test/resources/grammars/precedence/Test32/final_grammar.json
@@ -573,6 +573,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test34/final_grammar.json
+++ b/test/resources/grammars/precedence/Test34/final_grammar.json
@@ -427,6 +427,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test35/final_grammar.json
+++ b/test/resources/grammars/precedence/Test35/final_grammar.json
@@ -427,6 +427,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test36/final_grammar.json
+++ b/test/resources/grammars/precedence/Test36/final_grammar.json
@@ -1148,6 +1148,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test4/final_grammar.json
+++ b/test/resources/grammars/precedence/Test4/final_grammar.json
@@ -338,6 +338,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test5/final_grammar.json
+++ b/test/resources/grammars/precedence/Test5/final_grammar.json
@@ -275,6 +275,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test6/final_grammar.json
+++ b/test/resources/grammars/precedence/Test6/final_grammar.json
@@ -308,6 +308,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test7/final_grammar.json
+++ b/test/resources/grammars/precedence/Test7/final_grammar.json
@@ -328,6 +328,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test8/final_grammar.json
+++ b/test/resources/grammars/precedence/Test8/final_grammar.json
@@ -754,6 +754,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/grammars/precedence/Test9/final_grammar.json
+++ b/test/resources/grammars/precedence/Test9/final_grammar.json
@@ -436,6 +436,7 @@
         {
           "kind" : "Nonterminal",
           "name" : "E",
+          "label" : "child",
           "preConditions" : [ ],
           "postConditions" : [ ],
           "arguments" : [

--- a/test/resources/tests/ErrorRecoveryTest/test1/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test1/parse_tree.json
@@ -1,0 +1,158 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Nonterminal",
+                "name" : "expr",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "arguments" : [
+                  {
+                    "kind" : "Integer",
+                    "value" : 0
+                  }
+                ]
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "ErrorNode",
+              "start" : 0,
+              "end" : 3
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              },
+              "start" : 3,
+              "end" : 4
+            }
+          ],
+          "start" : 0,
+          "end" : 4
+        }
+      ],
+      "start" : 0,
+      "end" : 4
+    }
+  ],
+  "start" : 0,
+  "end" : 4
+}

--- a/test/resources/tests/ErrorRecoveryTest/test2/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test2/parse_tree.json
@@ -1,0 +1,1132 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Nonterminal",
+                "name" : "expr",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "arguments" : [
+                  {
+                    "kind" : "Integer",
+                    "value" : 0
+                  }
+                ]
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "NonterminalNode",
+              "rule" : {
+                "head" : {
+                  "kind" : "Nonterminal",
+                  "name" : "expr",
+                  "preConditions" : [ ],
+                  "postConditions" : [ ],
+                  "parameters" : [
+                    "p"
+                  ]
+                },
+                "body" : [
+                  {
+                    "kind" : "Nonterminal",
+                    "name" : "expr",
+                    "preConditions" : [
+                      {
+                        "kind" : "DataDependentCondition",
+                        "type" : "DATA_DEPENDENT",
+                        "expression" : {
+                          "kind" : "GreaterThanEqual",
+                          "lhs" : {
+                            "kind" : "Integer",
+                            "value" : 1
+                          },
+                          "rhs" : {
+                            "kind" : "Name",
+                            "name" : "p",
+                            "i" : -1
+                          }
+                        }
+                      }
+                    ],
+                    "postConditions" : [
+                      {
+                        "kind" : "DataDependentCondition",
+                        "type" : "DATA_DEPENDENT",
+                        "expression" : {
+                          "kind" : "Or",
+                          "lhs" : {
+                            "kind" : "LessThanEqual",
+                            "lhs" : {
+                              "kind" : "Name",
+                              "name" : "l",
+                              "i" : -1
+                            },
+                            "rhs" : {
+                              "kind" : "Integer",
+                              "value" : 0
+                            }
+                          },
+                          "rhs" : {
+                            "kind" : "GreaterThanEqual",
+                            "lhs" : {
+                              "kind" : "Name",
+                              "name" : "l",
+                              "i" : -1
+                            },
+                            "rhs" : {
+                              "kind" : "Integer",
+                              "value" : 1
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "variable" : "l",
+                    "arguments" : [
+                      {
+                        "kind" : "Name",
+                        "name" : "p",
+                        "i" : -1
+                      }
+                    ]
+                  },
+                  {
+                    "kind" : "Terminal",
+                    "name" : "'+'",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "nodeType" : "Literal",
+                    "regex" : {
+                      "kind" : "Char",
+                      "lookaheads" : [ ],
+                      "lookbehinds" : [ ],
+                      "val" : 43
+                    }
+                  },
+                  {
+                    "kind" : "Nonterminal",
+                    "name" : "expr",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "arguments" : [
+                      {
+                        "kind" : "Integer",
+                        "value" : 0
+                      }
+                    ]
+                  },
+                  {
+                    "kind" : "Return",
+                    "name" : "{1}",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "expression" : {
+                      "kind" : "Integer",
+                      "value" : 1
+                    }
+                  }
+                ],
+                "recursion" : "LEFT_RIGHT_REC",
+                "irecursion" : "NON_REC",
+                "leftEnd" : "",
+                "rightEnd" : "",
+                "leftEnds" : [ ],
+                "rightEnds" : [ ],
+                "associativity" : "UNDEFINED",
+                "precedence" : 1,
+                "precedenceLevel" : {
+                  "lhs" : 1,
+                  "rhs" : 1,
+                  "undefined" : 1,
+                  "hasPrefixUnary" : false,
+                  "hasPostfixUnary" : false,
+                  "hasPrefixUnaryBelow" : false,
+                  "prefixUnaryBelow" : [ ],
+                  "hasPostfixUnaryBelow" : false,
+                  "postfixUnaryBelow" : [ ],
+                  "index" : 2,
+                  "containsAssociativityGroup" : false,
+                  "assoc_lhs" : -1,
+                  "assoc_rhs" : -1
+                }
+              },
+              "children" : [
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "expr",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ],
+                      "parameters" : [
+                        "p"
+                      ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Plus"
+                      },
+                      {
+                        "kind" : "Return",
+                        "name" : "{0}",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "expression" : {
+                          "kind" : "Integer",
+                          "value" : 0
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : 1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 2,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "PlusNode",
+                      "symbol" : {
+                        "kind" : "Plus",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "s" : {
+                          "kind" : "Terminal",
+                          "name" : "(0-9)",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ],
+                          "nodeType" : "Regex",
+                          "regex" : {
+                            "kind" : "regex.Alt",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "symbols" : [
+                              {
+                                "kind" : "CharRange",
+                                "lookaheads" : [ ],
+                                "lookbehinds" : [ ],
+                                "start" : 48,
+                                "end" : 57
+                              }
+                            ]
+                          }
+                        },
+                        "separators" : [ ]
+                      },
+                      "children" : [
+                        {
+                          "kind" : "TerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "(0-9)",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Regex",
+                            "regex" : {
+                              "kind" : "regex.Alt",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "symbols" : [
+                                {
+                                  "kind" : "CharRange",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "start" : 48,
+                                  "end" : 57
+                                }
+                              ]
+                            }
+                          },
+                          "start" : 0,
+                          "end" : 1
+                        }
+                      ],
+                      "start" : 0,
+                      "end" : 1
+                    }
+                  ],
+                  "start" : 0,
+                  "end" : 1
+                },
+                {
+                  "kind" : "KeywordTerminalNode",
+                  "terminal" : {
+                    "kind" : "Terminal",
+                    "name" : "'+'",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "nodeType" : "Literal",
+                    "regex" : {
+                      "kind" : "Char",
+                      "lookaheads" : [ ],
+                      "lookbehinds" : [ ],
+                      "val" : 43
+                    }
+                  },
+                  "start" : 1,
+                  "end" : 2
+                },
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "expr",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ],
+                      "parameters" : [
+                        "p"
+                      ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Plus"
+                      },
+                      {
+                        "kind" : "Return",
+                        "name" : "{0}",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "expression" : {
+                          "kind" : "Integer",
+                          "value" : 0
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : 1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 2,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "PlusNode",
+                      "symbol" : {
+                        "kind" : "Plus",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "s" : {
+                          "kind" : "Terminal",
+                          "name" : "(0-9)",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ],
+                          "nodeType" : "Regex",
+                          "regex" : {
+                            "kind" : "regex.Alt",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "symbols" : [
+                              {
+                                "kind" : "CharRange",
+                                "lookaheads" : [ ],
+                                "lookbehinds" : [ ],
+                                "start" : 48,
+                                "end" : 57
+                              }
+                            ]
+                          }
+                        },
+                        "separators" : [ ]
+                      },
+                      "children" : [
+                        {
+                          "kind" : "TerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "(0-9)",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Regex",
+                            "regex" : {
+                              "kind" : "regex.Alt",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "symbols" : [
+                                {
+                                  "kind" : "CharRange",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "start" : 48,
+                                  "end" : 57
+                                }
+                              ]
+                            }
+                          },
+                          "start" : 2,
+                          "end" : 3
+                        }
+                      ],
+                      "start" : 2,
+                      "end" : 3
+                    }
+                  ],
+                  "start" : 2,
+                  "end" : 3
+                }
+              ],
+              "start" : 0,
+              "end" : 3
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              },
+              "start" : 3,
+              "end" : 4
+            }
+          ],
+          "start" : 0,
+          "end" : 4
+        },
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Nonterminal",
+                "name" : "expr",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "arguments" : [
+                  {
+                    "kind" : "Integer",
+                    "value" : 0
+                  }
+                ]
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "ErrorNode",
+              "start" : 4,
+              "end" : 7
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              },
+              "start" : 7,
+              "end" : 8
+            }
+          ],
+          "start" : 4,
+          "end" : 8
+        },
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Nonterminal",
+                "name" : "expr",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "arguments" : [
+                  {
+                    "kind" : "Integer",
+                    "value" : 0
+                  }
+                ]
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "NonterminalNode",
+              "rule" : {
+                "head" : {
+                  "kind" : "Nonterminal",
+                  "name" : "expr",
+                  "preConditions" : [ ],
+                  "postConditions" : [ ],
+                  "parameters" : [
+                    "p"
+                  ]
+                },
+                "body" : [
+                  {
+                    "kind" : "Nonterminal",
+                    "name" : "expr",
+                    "preConditions" : [
+                      {
+                        "kind" : "DataDependentCondition",
+                        "type" : "DATA_DEPENDENT",
+                        "expression" : {
+                          "kind" : "GreaterThanEqual",
+                          "lhs" : {
+                            "kind" : "Integer",
+                            "value" : 2
+                          },
+                          "rhs" : {
+                            "kind" : "Name",
+                            "name" : "p",
+                            "i" : -1
+                          }
+                        }
+                      }
+                    ],
+                    "postConditions" : [
+                      {
+                        "kind" : "DataDependentCondition",
+                        "type" : "DATA_DEPENDENT",
+                        "expression" : {
+                          "kind" : "Or",
+                          "lhs" : {
+                            "kind" : "LessThanEqual",
+                            "lhs" : {
+                              "kind" : "Name",
+                              "name" : "l",
+                              "i" : -1
+                            },
+                            "rhs" : {
+                              "kind" : "Integer",
+                              "value" : 0
+                            }
+                          },
+                          "rhs" : {
+                            "kind" : "GreaterThanEqual",
+                            "lhs" : {
+                              "kind" : "Name",
+                              "name" : "l",
+                              "i" : -1
+                            },
+                            "rhs" : {
+                              "kind" : "Integer",
+                              "value" : 2
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "variable" : "l",
+                    "arguments" : [
+                      {
+                        "kind" : "Name",
+                        "name" : "p",
+                        "i" : -1
+                      }
+                    ]
+                  },
+                  {
+                    "kind" : "Terminal",
+                    "name" : "'*'",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "nodeType" : "Literal",
+                    "regex" : {
+                      "kind" : "Char",
+                      "lookaheads" : [ ],
+                      "lookbehinds" : [ ],
+                      "val" : 42
+                    }
+                  },
+                  {
+                    "kind" : "Nonterminal",
+                    "name" : "expr",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "arguments" : [
+                      {
+                        "kind" : "Integer",
+                        "value" : 2
+                      }
+                    ]
+                  },
+                  {
+                    "kind" : "Return",
+                    "name" : "{2}",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "expression" : {
+                      "kind" : "Integer",
+                      "value" : 2
+                    }
+                  }
+                ],
+                "recursion" : "LEFT_RIGHT_REC",
+                "irecursion" : "NON_REC",
+                "leftEnd" : "",
+                "rightEnd" : "",
+                "leftEnds" : [ ],
+                "rightEnds" : [ ],
+                "associativity" : "UNDEFINED",
+                "precedence" : 2,
+                "precedenceLevel" : {
+                  "lhs" : 2,
+                  "rhs" : 2,
+                  "undefined" : 2,
+                  "hasPrefixUnary" : false,
+                  "hasPostfixUnary" : false,
+                  "hasPrefixUnaryBelow" : false,
+                  "prefixUnaryBelow" : [ ],
+                  "hasPostfixUnaryBelow" : false,
+                  "postfixUnaryBelow" : [ ],
+                  "index" : 3,
+                  "containsAssociativityGroup" : false,
+                  "assoc_lhs" : -1,
+                  "assoc_rhs" : -1
+                }
+              },
+              "children" : [
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "expr",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ],
+                      "parameters" : [
+                        "p"
+                      ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Plus"
+                      },
+                      {
+                        "kind" : "Return",
+                        "name" : "{0}",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "expression" : {
+                          "kind" : "Integer",
+                          "value" : 0
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : 1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 2,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "PlusNode",
+                      "symbol" : {
+                        "kind" : "Plus",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "s" : {
+                          "kind" : "Terminal",
+                          "name" : "(0-9)",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ],
+                          "nodeType" : "Regex",
+                          "regex" : {
+                            "kind" : "regex.Alt",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "symbols" : [
+                              {
+                                "kind" : "CharRange",
+                                "lookaheads" : [ ],
+                                "lookbehinds" : [ ],
+                                "start" : 48,
+                                "end" : 57
+                              }
+                            ]
+                          }
+                        },
+                        "separators" : [ ]
+                      },
+                      "children" : [
+                        {
+                          "kind" : "TerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "(0-9)",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Regex",
+                            "regex" : {
+                              "kind" : "regex.Alt",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "symbols" : [
+                                {
+                                  "kind" : "CharRange",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "start" : 48,
+                                  "end" : 57
+                                }
+                              ]
+                            }
+                          },
+                          "start" : 8,
+                          "end" : 9
+                        }
+                      ],
+                      "start" : 8,
+                      "end" : 9
+                    }
+                  ],
+                  "start" : 8,
+                  "end" : 9
+                },
+                {
+                  "kind" : "KeywordTerminalNode",
+                  "terminal" : {
+                    "kind" : "Terminal",
+                    "name" : "'*'",
+                    "preConditions" : [ ],
+                    "postConditions" : [ ],
+                    "nodeType" : "Literal",
+                    "regex" : {
+                      "kind" : "Char",
+                      "lookaheads" : [ ],
+                      "lookbehinds" : [ ],
+                      "val" : 42
+                    }
+                  },
+                  "start" : 9,
+                  "end" : 10
+                },
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "expr",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ],
+                      "parameters" : [
+                        "p"
+                      ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Plus"
+                      },
+                      {
+                        "kind" : "Return",
+                        "name" : "{0}",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "expression" : {
+                          "kind" : "Integer",
+                          "value" : 0
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : 1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 2,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "PlusNode",
+                      "symbol" : {
+                        "kind" : "Plus",
+                        "name" : "(0-9)+",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "s" : {
+                          "kind" : "Terminal",
+                          "name" : "(0-9)",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ],
+                          "nodeType" : "Regex",
+                          "regex" : {
+                            "kind" : "regex.Alt",
+                            "lookaheads" : [ ],
+                            "lookbehinds" : [ ],
+                            "symbols" : [
+                              {
+                                "kind" : "CharRange",
+                                "lookaheads" : [ ],
+                                "lookbehinds" : [ ],
+                                "start" : 48,
+                                "end" : 57
+                              }
+                            ]
+                          }
+                        },
+                        "separators" : [ ]
+                      },
+                      "children" : [
+                        {
+                          "kind" : "TerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "(0-9)",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Regex",
+                            "regex" : {
+                              "kind" : "regex.Alt",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "symbols" : [
+                                {
+                                  "kind" : "CharRange",
+                                  "lookaheads" : [ ],
+                                  "lookbehinds" : [ ],
+                                  "start" : 48,
+                                  "end" : 57
+                                }
+                              ]
+                            }
+                          },
+                          "start" : 10,
+                          "end" : 11
+                        }
+                      ],
+                      "start" : 10,
+                      "end" : 11
+                    }
+                  ],
+                  "start" : 10,
+                  "end" : 11
+                }
+              ],
+              "start" : 8,
+              "end" : 11
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "';'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 59
+                }
+              },
+              "start" : 11,
+              "end" : 12
+            }
+          ],
+          "start" : 8,
+          "end" : 12
+        }
+      ],
+      "start" : 0,
+      "end" : 12
+    }
+  ],
+  "start" : 0,
+  "end" : 12
+}

--- a/test/resources/tests/ErrorRecoveryTest/test3/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test3/parse_tree.json
@@ -1,0 +1,184 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              {
+                "kind" : "Nonterminal",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Plus"
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              "start" : 0,
+              "end" : 1
+            },
+            {
+              "kind" : "ErrorNode",
+              "start" : 1,
+              "end" : 4
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              },
+              "start" : 4,
+              "end" : 5
+            }
+          ],
+          "start" : 0,
+          "end" : 5
+        }
+      ],
+      "start" : 0,
+      "end" : 5
+    }
+  ],
+  "start" : 0,
+  "end" : 5
+}

--- a/test/resources/tests/ErrorRecoveryTest/test4/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test4/parse_tree.json
@@ -1,0 +1,184 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              {
+                "kind" : "Nonterminal",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Plus"
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              "start" : 0,
+              "end" : 1
+            },
+            {
+              "kind" : "ErrorNode",
+              "start" : 1,
+              "end" : 7
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              },
+              "start" : 7,
+              "end" : 8
+            }
+          ],
+          "start" : 0,
+          "end" : 8
+        }
+      ],
+      "start" : 0,
+      "end" : 8
+    }
+  ],
+  "start" : 0,
+  "end" : 8
+}

--- a/test/resources/tests/ErrorRecoveryTest/test5/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test5/parse_tree.json
@@ -1,0 +1,290 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              {
+                "kind" : "Nonterminal",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Plus"
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              "start" : 0,
+              "end" : 1
+            },
+            {
+              "kind" : "PlusNode",
+              "symbol" : {
+                "kind" : "Plus",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "s" : {
+                  "kind" : "Nonterminal",
+                  "name" : "stmt",
+                  "preConditions" : [ ],
+                  "postConditions" : [ ]
+                },
+                "separators" : [ ]
+              },
+              "children" : [
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "stmt",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "expr",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "arguments" : [
+                          {
+                            "kind" : "Integer",
+                            "value" : 0
+                          }
+                        ]
+                      },
+                      {
+                        "kind" : "Error"
+                      },
+                      {
+                        "kind" : "Terminal",
+                        "name" : "';'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 59
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : -1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 1,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "ErrorNode",
+                      "start" : 1,
+                      "end" : 4
+                    },
+                    {
+                      "kind" : "KeywordTerminalNode",
+                      "terminal" : {
+                        "kind" : "Terminal",
+                        "name" : "';'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 59
+                        }
+                      },
+                      "start" : 4,
+                      "end" : 5
+                    }
+                  ],
+                  "start" : 1,
+                  "end" : 5
+                }
+              ],
+              "start" : 1,
+              "end" : 5
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              },
+              "start" : 5,
+              "end" : 6
+            }
+          ],
+          "start" : 0,
+          "end" : 6
+        }
+      ],
+      "start" : 0,
+      "end" : 6
+    }
+  ],
+  "start" : 0,
+  "end" : 6
+}

--- a/test/resources/tests/ErrorRecoveryTest/test6/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test6/parse_tree.json
@@ -1,0 +1,777 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              {
+                "kind" : "Nonterminal",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Plus"
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              "start" : 0,
+              "end" : 1
+            },
+            {
+              "kind" : "PlusNode",
+              "symbol" : {
+                "kind" : "Plus",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "s" : {
+                  "kind" : "Nonterminal",
+                  "name" : "stmt",
+                  "preConditions" : [ ],
+                  "postConditions" : [ ]
+                },
+                "separators" : [ ]
+              },
+              "children" : [
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "stmt",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "expr",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "arguments" : [
+                          {
+                            "kind" : "Integer",
+                            "value" : 0
+                          }
+                        ]
+                      },
+                      {
+                        "kind" : "Error"
+                      },
+                      {
+                        "kind" : "Terminal",
+                        "name" : "';'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 59
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : -1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 1,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "ErrorNode",
+                      "start" : 1,
+                      "end" : 4
+                    },
+                    {
+                      "kind" : "KeywordTerminalNode",
+                      "terminal" : {
+                        "kind" : "Terminal",
+                        "name" : "';'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 59
+                        }
+                      },
+                      "start" : 4,
+                      "end" : 5
+                    }
+                  ],
+                  "start" : 1,
+                  "end" : 5
+                },
+                {
+                  "kind" : "NonterminalNode",
+                  "rule" : {
+                    "head" : {
+                      "kind" : "Nonterminal",
+                      "name" : "stmt",
+                      "preConditions" : [ ],
+                      "postConditions" : [ ]
+                    },
+                    "body" : [
+                      {
+                        "kind" : "Nonterminal",
+                        "name" : "expr",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "arguments" : [
+                          {
+                            "kind" : "Integer",
+                            "value" : 0
+                          }
+                        ]
+                      },
+                      {
+                        "kind" : "Error"
+                      },
+                      {
+                        "kind" : "Terminal",
+                        "name" : "';'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 59
+                        }
+                      }
+                    ],
+                    "recursion" : "NON_REC",
+                    "irecursion" : "NON_REC",
+                    "leftEnd" : "",
+                    "rightEnd" : "",
+                    "leftEnds" : [ ],
+                    "rightEnds" : [ ],
+                    "associativity" : "UNDEFINED",
+                    "precedence" : -1,
+                    "precedenceLevel" : {
+                      "lhs" : 1,
+                      "rhs" : 1,
+                      "undefined" : -1,
+                      "hasPrefixUnary" : false,
+                      "hasPostfixUnary" : false,
+                      "hasPrefixUnaryBelow" : false,
+                      "prefixUnaryBelow" : [ ],
+                      "hasPostfixUnaryBelow" : false,
+                      "postfixUnaryBelow" : [ ],
+                      "index" : 1,
+                      "containsAssociativityGroup" : false,
+                      "assoc_lhs" : -1,
+                      "assoc_rhs" : -1
+                    }
+                  },
+                  "children" : [
+                    {
+                      "kind" : "NonterminalNode",
+                      "rule" : {
+                        "head" : {
+                          "kind" : "Nonterminal",
+                          "name" : "expr",
+                          "preConditions" : [ ],
+                          "postConditions" : [ ],
+                          "parameters" : [
+                            "p"
+                          ]
+                        },
+                        "body" : [
+                          {
+                            "kind" : "Nonterminal",
+                            "name" : "expr",
+                            "preConditions" : [
+                              {
+                                "kind" : "DataDependentCondition",
+                                "type" : "DATA_DEPENDENT",
+                                "expression" : {
+                                  "kind" : "GreaterThanEqual",
+                                  "lhs" : {
+                                    "kind" : "Integer",
+                                    "value" : 2
+                                  },
+                                  "rhs" : {
+                                    "kind" : "Name",
+                                    "name" : "p",
+                                    "i" : -1
+                                  }
+                                }
+                              }
+                            ],
+                            "postConditions" : [
+                              {
+                                "kind" : "DataDependentCondition",
+                                "type" : "DATA_DEPENDENT",
+                                "expression" : {
+                                  "kind" : "Or",
+                                  "lhs" : {
+                                    "kind" : "LessThanEqual",
+                                    "lhs" : {
+                                      "kind" : "Name",
+                                      "name" : "l",
+                                      "i" : -1
+                                    },
+                                    "rhs" : {
+                                      "kind" : "Integer",
+                                      "value" : 0
+                                    }
+                                  },
+                                  "rhs" : {
+                                    "kind" : "GreaterThanEqual",
+                                    "lhs" : {
+                                      "kind" : "Name",
+                                      "name" : "l",
+                                      "i" : -1
+                                    },
+                                    "rhs" : {
+                                      "kind" : "Integer",
+                                      "value" : 2
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "variable" : "l",
+                            "arguments" : [
+                              {
+                                "kind" : "Name",
+                                "name" : "p",
+                                "i" : -1
+                              }
+                            ]
+                          },
+                          {
+                            "kind" : "Terminal",
+                            "name" : "'*'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 42
+                            }
+                          },
+                          {
+                            "kind" : "Nonterminal",
+                            "name" : "expr",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "arguments" : [
+                              {
+                                "kind" : "Integer",
+                                "value" : 2
+                              }
+                            ]
+                          },
+                          {
+                            "kind" : "Return",
+                            "name" : "{2}",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "expression" : {
+                              "kind" : "Integer",
+                              "value" : 2
+                            }
+                          }
+                        ],
+                        "recursion" : "LEFT_RIGHT_REC",
+                        "irecursion" : "NON_REC",
+                        "leftEnd" : "",
+                        "rightEnd" : "",
+                        "leftEnds" : [ ],
+                        "rightEnds" : [ ],
+                        "associativity" : "UNDEFINED",
+                        "precedence" : 2,
+                        "precedenceLevel" : {
+                          "lhs" : 2,
+                          "rhs" : 2,
+                          "undefined" : 2,
+                          "hasPrefixUnary" : false,
+                          "hasPostfixUnary" : false,
+                          "hasPrefixUnaryBelow" : false,
+                          "prefixUnaryBelow" : [ ],
+                          "hasPostfixUnaryBelow" : false,
+                          "postfixUnaryBelow" : [ ],
+                          "index" : 3,
+                          "containsAssociativityGroup" : false,
+                          "assoc_lhs" : -1,
+                          "assoc_rhs" : -1
+                        }
+                      },
+                      "children" : [
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "expr",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ],
+                              "parameters" : [
+                                "p"
+                              ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "(0-9)+",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Plus"
+                              },
+                              {
+                                "kind" : "Return",
+                                "name" : "{0}",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "expression" : {
+                                  "kind" : "Integer",
+                                  "value" : 0
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "PlusNode",
+                              "symbol" : {
+                                "kind" : "Plus",
+                                "name" : "(0-9)+",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "s" : {
+                                  "kind" : "Terminal",
+                                  "name" : "(0-9)",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ],
+                                  "nodeType" : "Regex",
+                                  "regex" : {
+                                    "kind" : "regex.Alt",
+                                    "lookaheads" : [ ],
+                                    "lookbehinds" : [ ],
+                                    "symbols" : [
+                                      {
+                                        "kind" : "CharRange",
+                                        "lookaheads" : [ ],
+                                        "lookbehinds" : [ ],
+                                        "start" : 48,
+                                        "end" : 57
+                                      }
+                                    ]
+                                  }
+                                },
+                                "separators" : [ ]
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "TerminalNode",
+                                  "terminal" : {
+                                    "kind" : "Terminal",
+                                    "name" : "(0-9)",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Regex",
+                                    "regex" : {
+                                      "kind" : "regex.Alt",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "symbols" : [
+                                        {
+                                          "kind" : "CharRange",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "start" : 48,
+                                          "end" : 57
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "start" : 5,
+                                  "end" : 6
+                                }
+                              ],
+                              "start" : 5,
+                              "end" : 6
+                            }
+                          ],
+                          "start" : 5,
+                          "end" : 6
+                        },
+                        {
+                          "kind" : "KeywordTerminalNode",
+                          "terminal" : {
+                            "kind" : "Terminal",
+                            "name" : "'*'",
+                            "preConditions" : [ ],
+                            "postConditions" : [ ],
+                            "nodeType" : "Literal",
+                            "regex" : {
+                              "kind" : "Char",
+                              "lookaheads" : [ ],
+                              "lookbehinds" : [ ],
+                              "val" : 42
+                            }
+                          },
+                          "start" : 6,
+                          "end" : 7
+                        },
+                        {
+                          "kind" : "NonterminalNode",
+                          "rule" : {
+                            "head" : {
+                              "kind" : "Nonterminal",
+                              "name" : "expr",
+                              "preConditions" : [ ],
+                              "postConditions" : [ ],
+                              "parameters" : [
+                                "p"
+                              ]
+                            },
+                            "body" : [
+                              {
+                                "kind" : "Nonterminal",
+                                "name" : "(0-9)+",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "nodeType" : "Plus"
+                              },
+                              {
+                                "kind" : "Return",
+                                "name" : "{0}",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "expression" : {
+                                  "kind" : "Integer",
+                                  "value" : 0
+                                }
+                              }
+                            ],
+                            "recursion" : "NON_REC",
+                            "irecursion" : "NON_REC",
+                            "leftEnd" : "",
+                            "rightEnd" : "",
+                            "leftEnds" : [ ],
+                            "rightEnds" : [ ],
+                            "associativity" : "UNDEFINED",
+                            "precedence" : -1,
+                            "precedenceLevel" : {
+                              "lhs" : 1,
+                              "rhs" : 1,
+                              "undefined" : 1,
+                              "hasPrefixUnary" : false,
+                              "hasPostfixUnary" : false,
+                              "hasPrefixUnaryBelow" : false,
+                              "prefixUnaryBelow" : [ ],
+                              "hasPostfixUnaryBelow" : false,
+                              "postfixUnaryBelow" : [ ],
+                              "index" : 2,
+                              "containsAssociativityGroup" : false,
+                              "assoc_lhs" : -1,
+                              "assoc_rhs" : -1
+                            }
+                          },
+                          "children" : [
+                            {
+                              "kind" : "PlusNode",
+                              "symbol" : {
+                                "kind" : "Plus",
+                                "name" : "(0-9)+",
+                                "preConditions" : [ ],
+                                "postConditions" : [ ],
+                                "s" : {
+                                  "kind" : "Terminal",
+                                  "name" : "(0-9)",
+                                  "preConditions" : [ ],
+                                  "postConditions" : [ ],
+                                  "nodeType" : "Regex",
+                                  "regex" : {
+                                    "kind" : "regex.Alt",
+                                    "lookaheads" : [ ],
+                                    "lookbehinds" : [ ],
+                                    "symbols" : [
+                                      {
+                                        "kind" : "CharRange",
+                                        "lookaheads" : [ ],
+                                        "lookbehinds" : [ ],
+                                        "start" : 48,
+                                        "end" : 57
+                                      }
+                                    ]
+                                  }
+                                },
+                                "separators" : [ ]
+                              },
+                              "children" : [
+                                {
+                                  "kind" : "TerminalNode",
+                                  "terminal" : {
+                                    "kind" : "Terminal",
+                                    "name" : "(0-9)",
+                                    "preConditions" : [ ],
+                                    "postConditions" : [ ],
+                                    "nodeType" : "Regex",
+                                    "regex" : {
+                                      "kind" : "regex.Alt",
+                                      "lookaheads" : [ ],
+                                      "lookbehinds" : [ ],
+                                      "symbols" : [
+                                        {
+                                          "kind" : "CharRange",
+                                          "lookaheads" : [ ],
+                                          "lookbehinds" : [ ],
+                                          "start" : 48,
+                                          "end" : 57
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "start" : 7,
+                                  "end" : 8
+                                }
+                              ],
+                              "start" : 7,
+                              "end" : 8
+                            }
+                          ],
+                          "start" : 7,
+                          "end" : 8
+                        }
+                      ],
+                      "start" : 5,
+                      "end" : 8
+                    },
+                    {
+                      "kind" : "KeywordTerminalNode",
+                      "terminal" : {
+                        "kind" : "Terminal",
+                        "name" : "';'",
+                        "preConditions" : [ ],
+                        "postConditions" : [ ],
+                        "nodeType" : "Literal",
+                        "regex" : {
+                          "kind" : "Char",
+                          "lookaheads" : [ ],
+                          "lookbehinds" : [ ],
+                          "val" : 59
+                        }
+                      },
+                      "start" : 8,
+                      "end" : 9
+                    }
+                  ],
+                  "start" : 5,
+                  "end" : 9
+                }
+              ],
+              "start" : 1,
+              "end" : 9
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              },
+              "start" : 9,
+              "end" : 10
+            }
+          ],
+          "start" : 0,
+          "end" : 10
+        }
+      ],
+      "start" : 0,
+      "end" : 10
+    }
+  ],
+  "start" : 0,
+  "end" : 10
+}

--- a/test/resources/tests/ErrorRecoveryTest/test7/parse_tree.json
+++ b/test/resources/tests/ErrorRecoveryTest/test7/parse_tree.json
@@ -1,0 +1,184 @@
+{
+  "kind" : "NonterminalNode",
+  "rule" : {
+    "head" : {
+      "kind" : "Nonterminal",
+      "name" : "program",
+      "preConditions" : [ ],
+      "postConditions" : [ ]
+    },
+    "body" : [
+      {
+        "kind" : "Nonterminal",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "nodeType" : "Plus"
+      }
+    ],
+    "recursion" : "NON_REC",
+    "irecursion" : "NON_REC",
+    "leftEnd" : "",
+    "rightEnd" : "",
+    "leftEnds" : [ ],
+    "rightEnds" : [ ],
+    "associativity" : "UNDEFINED",
+    "precedence" : -1,
+    "precedenceLevel" : {
+      "lhs" : 1,
+      "rhs" : 1,
+      "undefined" : -1,
+      "hasPrefixUnary" : false,
+      "hasPostfixUnary" : false,
+      "hasPrefixUnaryBelow" : false,
+      "prefixUnaryBelow" : [ ],
+      "hasPostfixUnaryBelow" : false,
+      "postfixUnaryBelow" : [ ],
+      "index" : 1,
+      "containsAssociativityGroup" : false,
+      "assoc_lhs" : -1,
+      "assoc_rhs" : -1
+    }
+  },
+  "children" : [
+    {
+      "kind" : "PlusNode",
+      "symbol" : {
+        "kind" : "Plus",
+        "name" : "stmt+",
+        "preConditions" : [ ],
+        "postConditions" : [ ],
+        "s" : {
+          "kind" : "Nonterminal",
+          "name" : "stmt",
+          "preConditions" : [ ],
+          "postConditions" : [ ]
+        },
+        "separators" : [ ]
+      },
+      "children" : [
+        {
+          "kind" : "NonterminalNode",
+          "rule" : {
+            "head" : {
+              "kind" : "Nonterminal",
+              "name" : "stmt",
+              "preConditions" : [ ],
+              "postConditions" : [ ]
+            },
+            "body" : [
+              {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              {
+                "kind" : "Nonterminal",
+                "name" : "stmt+",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Plus"
+              },
+              {
+                "kind" : "Error"
+              },
+              {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              }
+            ],
+            "recursion" : "NON_REC",
+            "irecursion" : "NON_REC",
+            "leftEnd" : "",
+            "rightEnd" : "",
+            "leftEnds" : [ ],
+            "rightEnds" : [ ],
+            "associativity" : "UNDEFINED",
+            "precedence" : -1,
+            "precedenceLevel" : {
+              "lhs" : 1,
+              "rhs" : 1,
+              "undefined" : -1,
+              "hasPrefixUnary" : false,
+              "hasPostfixUnary" : false,
+              "hasPrefixUnaryBelow" : false,
+              "prefixUnaryBelow" : [ ],
+              "hasPostfixUnaryBelow" : false,
+              "postfixUnaryBelow" : [ ],
+              "index" : 1,
+              "containsAssociativityGroup" : false,
+              "assoc_lhs" : -1,
+              "assoc_rhs" : -1
+            }
+          },
+          "children" : [
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'{'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 123
+                }
+              },
+              "start" : 0,
+              "end" : 1
+            },
+            {
+              "kind" : "ErrorNode",
+              "start" : 1,
+              "end" : 8
+            },
+            {
+              "kind" : "KeywordTerminalNode",
+              "terminal" : {
+                "kind" : "Terminal",
+                "name" : "'}'",
+                "preConditions" : [ ],
+                "postConditions" : [ ],
+                "nodeType" : "Literal",
+                "regex" : {
+                  "kind" : "Char",
+                  "lookaheads" : [ ],
+                  "lookbehinds" : [ ],
+                  "val" : 125
+                }
+              },
+              "start" : 8,
+              "end" : 9
+            }
+          ],
+          "start" : 0,
+          "end" : 9
+        }
+      ],
+      "start" : 0,
+      "end" : 9
+    }
+  ],
+  "start" : 0,
+  "end" : 9
+}


### PR DESCRIPTION
This PR adds the first version of an error recovery mechanism for Iguana. The error recovery mechanism is similar to the panic mode error recovery found in recursive descent parsers. We add the special `error` symbol to the grammar that provides synchronization points. When a parse error occurs, we empty the stack (by traversing the GSS) to find the synchronization points and continue parsing from there. Given the non-deterministic nature of GLL, the error recovery should happen after parsing is finished.